### PR TITLE
Implement DESC TYPE command

### DIFF
--- a/graphene/commands/desc_type_command.py
+++ b/graphene/commands/desc_type_command.py
@@ -1,0 +1,13 @@
+from enum import Enum
+from graphene.commands.command import Command
+from graphene.utils import PrettyPrinter
+from graphene.storage import GeneralStore
+
+class DescTypeCommand(Command):
+    def __init__(self, type_name):
+        self.type_name = type_name
+
+    def execute(self, storage_manager):
+        type_data, type_schema = storage_manager.get_node_data(self.type_name)
+        values = [(tt_name, tt_type.name) for tt, tt_name, tt_type in type_schema]
+        PrettyPrinter.print_table(values, header=("Name", "Type"))

--- a/graphene/parser/GQL.g4
+++ b/graphene/parser/GQL.g4
@@ -17,7 +17,7 @@ stmt
   : ( c=match_stmt
     | c=create_stmt | c=delete_stmt
     | c=exit_stmt
-    | c=show_stmt
+    | c=show_stmt | c=desc_stmt
     | c=insert_stmt
     )
   ;
@@ -153,6 +153,13 @@ show_stmt returns [cmd]
   {$cmd = ShowCommand(t)}
   ;
 
+// DESC command
+desc_stmt returns [cmd]
+  @init {$cmd = None}
+  : K_DESC (K_TYPE (t=I_TYPE {$t=$t.text}))
+  {$cmd = DescTypeCommand($t)}
+  ;
+
 // INSERT command
 insert_stmt returns [cmd]
   @init {$cmd = None}
@@ -208,6 +215,7 @@ K_DELETE : D E L E T E ;
 K_EXIT : E X I T ;
 K_QUIT : Q U I T ;
 K_SHOW : S H O W ;
+K_DESC : D E S C ;
 K_INSERT : I N S E R T ;
 
 K_TYPE : T Y P E ;

--- a/graphene/utils/pretty_printer.py
+++ b/graphene/utils/pretty_printer.py
@@ -27,7 +27,7 @@ class PrettyPrinter:
             maxes = [max(m, len(str(header[i] or ""))) for i, m in enumerate(maxes)]
             width = sum(m + 2 for m in maxes) + 2 + (len(maxes) - 1)
             output.write(width * "-" + "\n")
-            output.write("|%s|" % "|".join(" %s%s " % (v, (maxes[i] - len(str(v))) * " ") \
+            output.write("|%s|" % "|".join(" %s%s " % (v.upper(), (maxes[i] - len(str(v))) * " ") \
                    for i, v in enumerate(header)) + "\n")
         output.write(width * "-" + "\n")
         for row in table:


### PR DESCRIPTION
Implements DESC TYPE. Only works on one Type. Doesn't do any error checking on its own, but that should be doing somewhere else lower in abstractions.

DESC currently only accepts Types, but later we will add relations.
