### PR TITLE
Logging

### DIFF
--- a/graphene/client/client.py
+++ b/graphene/client/client.py
@@ -1,11 +1,15 @@
 from graphene.client.shell import Shell
 from graphene.server.server import GrapheneServer
+from graphene.utils.gp_logging import *
 
 if __name__ == "__main__":
     server = GrapheneServer()
 
     shell = Shell(server)
     try:
+        # Initialize logger with config file
+        GPLogging()
+        # Begin command loop
         shell.cmdloop()
     except KeyboardInterrupt:
         pass

--- a/graphene/client/shell.py
+++ b/graphene/client/shell.py
@@ -2,6 +2,8 @@ import cmd
 import readline
 import traceback
 import sys
+import logging
+
 
 class Shell(cmd.Cmd):
     def __init__(self, server):
@@ -14,9 +16,25 @@ class Shell(cmd.Cmd):
         self.completekey = "Tab"
 
     def do_help(self, line):
-        # Help message.
-        # TODO: Actually be helpful
-        pass
+        """
+        Prints help message when the following command is executed:
+            > help [line]
+
+        :param line: Line following help command used to identify help request
+        :type line: str
+        :return: Nothing
+        :rtype: None
+        """
+        # TODO: implement for different types of commands
+        # Make the line whitespace and case insensitive
+        line = line.upper().strip()
+
+        if line == "MATCH":
+            print("MATCH help: ")
+        else:
+            print("You can type the following help topics: \n"
+                  "MATCH, INSERT, CREATE")
+            logging.debug("Unhandled help request %s" % line)
 
     def do_EOF(self, line):
         return True

--- a/graphene/client/shell.py
+++ b/graphene/client/shell.py
@@ -9,6 +9,7 @@ class Shell(cmd.Cmd):
     def __init__(self, server):
         cmd.Cmd.__init__(self)
         self.server = server
+        self.logger = logging.getLogger(self.__class__.__name__)
 
     def preloop(self):
         self.intro = "Graphene 0.1"
@@ -34,7 +35,7 @@ class Shell(cmd.Cmd):
         else:
             print("You can type the following help topics: \n"
                   "MATCH, INSERT, CREATE")
-            logging.debug("Unhandled help request %s" % line)
+            self.logger.debug("Unhandled help request %s" % line)
 
     def do_EOF(self, line):
         return True

--- a/graphene/utils/gp_logging.py
+++ b/graphene/utils/gp_logging.py
@@ -1,0 +1,13 @@
+from logging import config
+
+
+class GPLogging:
+    """
+    Sets up the logging configuration file, only needs to be done once
+    """
+
+    LOGGING_FILE_NAME = "logging.conf"
+
+    def __init__(self):
+        config.fileConfig(self.LOGGING_FILE_NAME,
+                          disable_existing_loggers=False)

--- a/logging.conf
+++ b/logging.conf
@@ -1,15 +1,15 @@
-# Set key values
+# ---- Key Values ---- #
 
 [loggers]
-keys=root
+keys=root,Shell
 
 [handlers]
-keys=rootHandler
+keys=simpleHandler,shellHandler
 
 [formatters]
 keys=simple,complex
 
-# Formatters
+# ---- Formatters ---- #
 
 [formatter_simple]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
@@ -17,15 +17,30 @@ format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
 [formatter_complex]
 format=%(asctime)s - %(name)s - %(levelname)s - %(module)s : %(lineno)d - %(message)s
 
-# Loggers
+# ----- Loggers ----- #
 
+# - Root - #
 [logger_root]
-level=DEBUG
-handlers=rootHandler
+level=NOTSET
+handlers=simpleHandler
 
-# Handlers
+# - Shell - #
 
-[handler_rootHandler]
+[logger_Shell]
+qualname=Shell
+level=WARNING
+handlers=shellHandler
+# Used to prevent the handler from printing out the message twice
+propagate=0
+
+# ---- Handlers ---- #
+
+[handler_simpleHandler]
 class=StreamHandler
-formatter=complex
+formatter=simple
+args=()
+
+[handler_shellHandler]
+class=StreamHandler
+formatter=simple
 args=()

--- a/logging.conf
+++ b/logging.conf
@@ -1,0 +1,31 @@
+# Set key values
+
+[loggers]
+keys=root
+
+[handlers]
+keys=rootHandler
+
+[formatters]
+keys=simple,complex
+
+# Formatters
+
+[formatter_simple]
+format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+
+[formatter_complex]
+format=%(asctime)s - %(name)s - %(levelname)s - %(module)s : %(lineno)d - %(message)s
+
+# Loggers
+
+[logger_root]
+level=DEBUG
+handlers=rootHandler
+
+# Handlers
+
+[handler_rootHandler]
+class=StreamHandler
+formatter=complex
+args=()


### PR DESCRIPTION
Logging output for shell and a root logger for general logging. Class loggers can be created following a format similar to the one for the Shell class logger. The root logger can be used for general logging, but each class should have it's own logger so this is discouraged.
