### PR TITLE
Matching Relations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,7 +113,7 @@ todo_include_todos = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'classic'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/graphene/commands/insert_relation_command.py
+++ b/graphene/commands/insert_relation_command.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 from graphene.commands.command import Command
 from graphene.storage import StorageManager
+from graphene.expressions import *
 from graphene.traversal import *
 from graphene.utils.conversion import TypeConversion
 from graphene.errors import TypeMismatchException
@@ -41,14 +42,16 @@ class InsertRelationCommand(Command):
         rel_type, rel_schema = storage_manager.get_relationship_data(rel_name)
         rel_props = self.parse_properties(rel_props, rel_schema, storage_manager)
 
-        type_data1, type_schema1 = storage_manager.get_node_data(type1)
-        type_data2, type_schema2 = storage_manager.get_node_data(type2)
+        type_data1, type_schema_data1 = storage_manager.get_node_data(type1)
+        type_data2, type_schema_data2 = storage_manager.get_node_data(type2)
 
+        type_schema1 = [(tt_name, tt_type) for _, tt_name, tt_type in type_schema_data1]
+        type_schema2 = [(tt_name, tt_type) for _, tt_name, tt_type in type_schema_data2]
         qc1 = Query.parse_chain(storage_manager, queries1, type_schema1)
         qc2 = Query.parse_chain(storage_manager, queries2, type_schema2)
 
-        iter1 = NodeIterator(storage_manager, type_data1, type_schema1, queries=qc1)
-        iter2 = NodeIterator(storage_manager, type_data2, type_schema2, queries=qc2)
+        iter1 = NodeIterator(storage_manager, MatchNode(None, type1), type_schema1, queries=qc1)
+        iter2 = NodeIterator(storage_manager, MatchNode(None, type2), type_schema2, queries=qc2)
 
         inserted_relations = []
 

--- a/graphene/commands/insert_relation_command.py
+++ b/graphene/commands/insert_relation_command.py
@@ -12,9 +12,21 @@ import itertools
 class InsertRelationCommand(Command):
     def __init__(self, ctx):
         self.rel, self.query1, self.query2 = ctx
-        print("rel, query1, query2:", self.rel, self.query1, self.query2)
 
     def parse_properties(self, prop_list, schema, storage_manager):
+        """
+        Takes a list of properties that are intended to be inserted into the
+        relation, check that they match the schema of the relation (in order),
+        and then convert them to the desired type.
+
+        :type prop_list: list
+        :param prop_list: list of properties
+        :type schema: list
+        :param schema: list of tuples (type-type, property name, expected type)
+        :type storage_manager: StorageManager
+        :param storage_manager: storage manager for the calling instance
+        :return: List of properties
+        """
         properties = []
         for prop, schema_tt in zip(prop_list, schema):
             tt, prop_name, exp_tt = schema_tt
@@ -34,22 +46,30 @@ class InsertRelationCommand(Command):
 
         :type storage_manager: StorageManager
         :param storage_manager: storage manager for this instance
-        :return: None
+        :return: List of inserted relations
         """
-        type1, queries1 = self.query1
-        type2, queries2 = self.query2
-        rel_name, rel_props = self.rel
+        # Gather information about the relation: name, type, schema and properties
+        rel_name = self.rel[0]
         rel_type, rel_schema = storage_manager.get_relationship_data(rel_name)
-        rel_props = self.parse_properties(rel_props, rel_schema, storage_manager)
+        rel_props = self.parse_properties(self.rel[1], rel_schema, storage_manager)
 
+        # Determine type and schema information for type 1 (the left side of the
+        # relation)
+        type1, queries1 = self.query1
         type_data1, type_schema_data1 = storage_manager.get_node_data(type1)
-        type_data2, type_schema_data2 = storage_manager.get_node_data(type2)
-
         type_schema1 = [(tt_name, tt_type) for _, tt_name, tt_type in type_schema_data1]
+
+        # Determine type and schema information for type 2 (the right side of the
+        # relation)
+        type2, queries2 = self.query2
+        type_data2, type_schema_data2 = storage_manager.get_node_data(type2)
         type_schema2 = [(tt_name, tt_type) for _, tt_name, tt_type in type_schema_data2]
+
+        # Parse queries for the left and right nodes
         qc1 = Query.parse_chain(storage_manager, queries1, type_schema1)
         qc2 = Query.parse_chain(storage_manager, queries2, type_schema2)
 
+        # Create iterators for the left and right nodes
         iter1 = NodeIterator(storage_manager, MatchNode(None, type1), type_schema1, queries=qc1)
         iter2 = NodeIterator(storage_manager, MatchNode(None, type2), type_schema2, queries=qc2)
 
@@ -62,9 +82,10 @@ class InsertRelationCommand(Command):
             if np1 == np2:
                 continue
 
-            print("Inserting relation %s between %s and %s" %
+            print("Inserting relation %s between %s and %s" % \
                 (rel_name, np1.node, np2.node))
-            rel = storage_manager.insert_relation(rel_type, rel_props, np1.node, np2.node)
+            rel = storage_manager.insert_relation(rel_type, rel_props,
+                np1.node, np2.node)
             inserted_relations.append(rel)
 
         return inserted_relations

--- a/graphene/commands/match_command.py
+++ b/graphene/commands/match_command.py
@@ -19,37 +19,6 @@ class MatchCommand(Command):
         # Create a planner and execute given a node chain and query chain
         planner = QueryPlanner(storage_manager)
         schema, results = planner.execute(self.nc, self.qc, self.rc)
-        # if len(self.rc) == 0:
-        #     # If there's no return statement, we do nothing to the columns
-        #     return_filter = lambda x: x
-        # else:
-        #     indexes = []
-        #     schema_names = [name for tt, name, ttype in type_schema]
-        #     for r in self.rc:
-        #         ident, name = r
-        #         # If there is an identifier given (e.g. `MATCH (a:A)`), then we
-        #         # check that if one was given with the return query that it
-        #         # matches the one we are looking at with the current schema.
-        #         # That is, if our selection is `MATCH (a:A)`, where A has fields
-        #         # b or c, then `RETURN b, c` and `RETURN a.b, a.c` both work and
-        #         # do the same thing, but `RETURN a` and `RETURN t.b` do not.
-        #         if (ident == alias or ident is None) and name in schema_names:
-        #             indexes.append(schema_names.index(name))
-        #     return_filter = lambda l: [l[i] for i in indexes]
-
-        # # Filter out the header columns with respect to the RETURN clause, if
-        # # one was provided
-        # header = return_filter([name.upper() for tt, name, ttype in type_schema])
-
-        # # We use a NodeIterator here to loop through the table. TODO: Determine
-        # # whether we want to put return filtering in the iterator or just do it
-        # # afterwards
-        # iterator = NodeIterator(storage_manager, type_data, type_schema,
-        #                         alias, qc)
-
-        # values = []
-        # for node in iterator:
-        #     values.append(return_filter(node.properties))
 
         # If there's nothing found, there were no nodes
         if len(results) == 0:

--- a/graphene/commands/match_command.py
+++ b/graphene/commands/match_command.py
@@ -3,6 +3,7 @@ import sys
 from graphene.traversal import *
 from graphene.commands.command import Command
 from graphene.utils import PrettyPrinter
+from graphene.query.planner import QueryPlanner
 
 class MatchCommand(Command):
     def __init__(self, node_chain, query_chain):
@@ -14,19 +15,13 @@ class MatchCommand(Command):
         return "[Match\n%s\n]" % "\n".join(lst)
 
     def execute(self, storage_manager, output=sys.stdout):
-        # TODO: handle relationships, passes a True argument for node flag
-        first_match = self.nc[0]
-        alias = first_match.name
-        type_data, type_schema = storage_manager.get_node_data(first_match.type)
-        qc = Query.parse_chain(storage_manager, self.qc, type_schema, alias)
-
-        header = [name.upper() for tt, name, ttype in type_schema]
-        iterator = NodeIterator(storage_manager, type_data, type_schema, alias, qc)
-        values = []
-        for node in iterator:
-            values.append(node.properties)
-        if len(values) == 0:
+        # Create a planner and execute given a node chain and query chain
+        planner = QueryPlanner(storage_manager)
+        schema, results = planner.execute(self.nc, self.qc)
+        # If there's nothing found, there were no nodes
+        if len(results) == 0:
             output.write("No nodes found.\n")
             return []
-        PrettyPrinter.print_table(values, header, output)
-        return values
+
+        PrettyPrinter.print_table(results, schema, output)
+        return results

--- a/graphene/commands/match_command.py
+++ b/graphene/commands/match_command.py
@@ -16,6 +16,15 @@ class MatchCommand(Command):
         return "[Match\n%s\n]" % "\n".join(lst)
 
     def execute(self, storage_manager, output=sys.stdout):
+        """
+        Runs a MATCH query against the server
+
+        :type storage_manager: StorageManager
+        :param storage_manager: storage manager for this instance
+        :type output: file
+        :param output: The file stream to pipe output into
+        :return: List of results
+        """
         # Create a planner and execute given a node chain and query chain
         planner = QueryPlanner(storage_manager)
         schema, results = planner.execute(self.nc, self.qc, self.rc)

--- a/graphene/commands/match_command.py
+++ b/graphene/commands/match_command.py
@@ -5,9 +5,10 @@ from graphene.commands.command import Command
 from graphene.utils import PrettyPrinter
 
 class MatchCommand(Command):
-    def __init__(self, node_chain, query_chain):
+    def __init__(self, node_chain, query_chain, return_chain):
         self.nc = node_chain
         self.qc = query_chain or ()
+        self.rc = return_chain or ()
 
     def __repr__(self):
         lst = ["\t%s" % chain for chain in self.nc]
@@ -20,11 +21,22 @@ class MatchCommand(Command):
         type_data, type_schema = storage_manager.get_node_data(first_match.type)
         qc = Query.parse_chain(storage_manager, self.qc, type_schema, alias)
 
-        header = [name.upper() for tt, name, ttype in type_schema]
+        if len(self.rc) == 0:
+            return_filter = lambda x: x
+        else:
+            indexes = []
+            schema_names = [name for tt, name, ttype in type_schema]
+            for r in self.rc:
+                ident, name = r
+                if (ident == alias or ident is None) and name in schema_names:
+                    indexes.append(schema_names.index(name))
+            return_filter = lambda l: [l[i] for i in indexes]
+
+        header = return_filter([name.upper() for tt, name, ttype in type_schema])
         iterator = NodeIterator(storage_manager, type_data, type_schema, alias, qc)
         values = []
         for node in iterator:
-            values.append(node.properties)
+            values.append(return_filter(node.properties))
         if len(values) == 0:
             output.write("No nodes found.\n")
             return []

--- a/graphene/commands/match_command.py
+++ b/graphene/commands/match_command.py
@@ -18,7 +18,7 @@ class MatchCommand(Command):
     def execute(self, storage_manager, output=sys.stdout):
         # Create a planner and execute given a node chain and query chain
         planner = QueryPlanner(storage_manager)
-        schema, results = planner.execute(self.nc, self.qc)
+        schema, results = planner.execute(self.nc, self.qc, self.rc)
         # if len(self.rc) == 0:
         #     # If there's no return statement, we do nothing to the columns
         #     return_filter = lambda x: x

--- a/graphene/commands/match_command.py
+++ b/graphene/commands/match_command.py
@@ -22,18 +22,33 @@ class MatchCommand(Command):
         qc = Query.parse_chain(storage_manager, self.qc, type_schema, alias)
 
         if len(self.rc) == 0:
+            # If there's no return statement, we do nothing to the columns
             return_filter = lambda x: x
         else:
             indexes = []
             schema_names = [name for tt, name, ttype in type_schema]
             for r in self.rc:
                 ident, name = r
+                # If there is an identifier given (e.g. `MATCH (a:A)`), then we
+                # check that if one was given with the return query that it
+                # matches the one we are looking at with the current schema.
+                # That is, if our selection is `MATCH (a:A)`, where A has fields
+                # b or c, then `RETURN b, c` and `RETURN a.b, a.c` both work and
+                # do the same thing, but `RETURN a` and `RETURN t.b` do not.
                 if (ident == alias or ident is None) and name in schema_names:
                     indexes.append(schema_names.index(name))
             return_filter = lambda l: [l[i] for i in indexes]
 
+        # Filter out the header columns with respect to the RETURN clause, if
+        # one was provided
         header = return_filter([name.upper() for tt, name, ttype in type_schema])
-        iterator = NodeIterator(storage_manager, type_data, type_schema, alias, qc)
+
+        # We use a NodeIterator here to loop through the table. TODO: Determine
+        # whether we want to put return filtering in the iterator or just do it
+        # afterwards
+        iterator = NodeIterator(storage_manager, type_data, type_schema,
+                                alias, qc)
+
         values = []
         for node in iterator:
             values.append(return_filter(node.properties))

--- a/graphene/errors/__init__.py
+++ b/graphene/errors/__init__.py
@@ -1,1 +1,2 @@
 from storage_manager_errors import *
+from query_errors import *

--- a/graphene/errors/query_errors.py
+++ b/graphene/errors/query_errors.py
@@ -1,0 +1,17 @@
+"""
+Query custom exceptions.
+"""
+
+
+class NonexistentPropertyException(Exception):
+    """Error for creating a type that already exists."""
+    pass
+
+
+class DuplicatePropertyException(Exception):
+    """Error for attempting to get type data for a non-existent type."""
+    pass
+
+class AmbiguousPropertyException(Exception):
+    """Error for attempting to store the incorrect data type for a property."""
+    pass

--- a/graphene/query/__init__.py
+++ b/graphene/query/__init__.py
@@ -1,0 +1,1 @@
+from project_stream import ProjectStream

--- a/graphene/query/planner.py
+++ b/graphene/query/planner.py
@@ -1,4 +1,5 @@
 from graphene.traversal import *
+from graphene.query import ProjectStream
 from graphene.expressions import MatchNode, MatchRelation
 
 class QueryPlanner:
@@ -75,7 +76,7 @@ class QueryPlanner:
                 elif num_occur == 0:
                     raise Exception("Property name `%s` does not exist." % qc[1])
 
-    def execute(self, node_chain, query_chain):
+    def execute(self, node_chain, query_chain, return_chain):
         # Gather schema information from node chain. Collects all property names
         schema = self.get_schema(node_chain)
 
@@ -96,6 +97,11 @@ class QueryPlanner:
         else:
             for props, right in self.create_relation_tree(node_chain, query_chain):
                 results.append(props)
+
+        if len(return_chain) > 0:
+            stream = ProjectStream(return_chain, schema, results)
+            schema_names = stream.schema_names
+            results = list(stream)
 
         # TODO: Strip property columns where the node/relation was not supplied
         # an alias

--- a/graphene/query/planner.py
+++ b/graphene/query/planner.py
@@ -117,6 +117,10 @@ class QueryPlanner:
                     raise NonexistentPropertyException("Property name `%s` does not exist." % qc[1])
 
     def execute(self, node_chain, query_chain, return_chain):
+        if query_chain is None:
+            query_chain = ()
+        if return_chain is None:
+            return_chain = ()
         # Gather schema information from node chain. Collects all property names
         schema = self.get_schema(node_chain, fullset=True)
 

--- a/graphene/query/planner.py
+++ b/graphene/query/planner.py
@@ -1,0 +1,102 @@
+from graphene.traversal import *
+from graphene.expressions import MatchNode, MatchRelation
+
+class QueryPlanner:
+    def __init__(self, storage_manager):
+        self.sm = storage_manager
+
+    def reduce_query_chain(self, query_chain, schema, alias=None, throw=False):
+        new_chain = []
+        base_names = [n.split(".")[-1] for n, t in schema]
+        for qc in query_chain:
+            if type(qc) != tuple:
+                # Boolean logic, ignore for now
+                continue
+            elif (qc[0] == alias and qc[1] in base_names) \
+                or (qc[0] == None and qc[1] in base_names):
+                new_chain.append(qc)
+            elif throw:
+                raise Exception("No such property name: " + qc[1])
+        return Query.parse_chain(self.sm, new_chain, schema)
+
+    def create_relation_tree(self, node_chain, query_chain):
+        if len(node_chain) == 1:
+            node = node_chain[0]
+            schema = self.get_schema(node_chain)
+            qc = self.reduce_query_chain(query_chain, schema, node.name)
+            return NodeIterator(self.sm, node, schema, qc)
+        else:
+            full_schema = self.get_schema(node_chain)
+            right_schema = self.get_schema([node_chain[-1]])
+            right_qc = self.reduce_query_chain(query_chain, right_schema, node_chain[-1].name)
+            left, rel, right = node_chain[:-2], node_chain[-2], \
+                NodeIterator(self.sm, node_chain[-1], right_schema, right_qc)
+            rel_schema = self.get_schema([rel])
+            rel_qc = self.reduce_query_chain(query_chain, rel_schema, rel.name)
+            return RelationIterator(self.sm, rel,
+                self.create_relation_tree(left, query_chain), right, rel_schema, rel_qc)
+
+    def get_schema(self, node_chain):
+        schema = []
+        schema_keys = []
+        for nc in node_chain:
+            if isinstance(nc, MatchNode):
+                schema_data = self.sm.get_node_data(nc.type)[1]
+            else:
+                schema_data = self.sm.get_relationship_data(nc.type)[1]
+            for tt, tt_name, tt_type in schema_data:
+                if nc.name is None:
+                    key = tt_name
+                else:
+                    key = "%s.%s" % (nc.name, tt_name)
+                if key in schema_keys:
+                    raise Exception("Duplicate property name `%s` in query. " \
+                        "Try adding an identifier." % key)
+                schema_keys.append(key)
+                schema.append((key, tt_type))
+        return schema
+
+    def check_query(self, schema, node_chain, query_chain):
+        schema_names = [n for n, tt in schema]
+        base_names = [n.split(".")[-1] for n, tt in schema]
+        for qc in query_chain:
+            if type(qc) != tuple:
+                # Boolean logic, ignore for now
+                continue
+            if qc[0] is not None:
+                key = "%s.%s" % (qc[0], qc[1])
+                if key not in schema_names:
+                    raise Exception("Property name `%s` does not exist." % key)
+            else:
+                num_occur = base_names.count(qc[1])
+                # Occurs more than once, it's ambiguous
+                if num_occur > 1:
+                    raise Exception("Property name `%s` is ambiguous. Please add an identifier." % qc[1])
+                elif num_occur == 0:
+                    raise Exception("Property name `%s` does not exist." % qc[1])
+
+    def execute(self, node_chain, query_chain):
+        # Gather schema information from node chain. Collects all property names
+        schema = self.get_schema(node_chain)
+
+        # Check query against schema to ensure no ambiguous or nonexistent properties are being queried
+        schema_names = [n for n, tt in schema]
+        self.check_query(schema, node_chain, query_chain)
+
+        # Gather results
+        results = []
+
+        # TODO: Make it so NodeIterator and RelationIterator return same
+        # kind of thing (i.e. RI returns (props, rightNode), NI returns a
+        # NodeProperty instance)
+        if len(node_chain) == 1:
+            # NodeIterator returns slightly different structure than RelationshipIterator
+            for nodeprop in self.create_relation_tree(node_chain, query_chain):
+                results.append(nodeprop.properties)
+        else:
+            for props, right in self.create_relation_tree(node_chain, query_chain):
+                results.append(props)
+
+        # TODO: Strip property columns where the node/relation was not supplied
+        # an alias
+        return (schema_names, results)

--- a/graphene/query/project_stream.py
+++ b/graphene/query/project_stream.py
@@ -1,0 +1,49 @@
+class ProjectStream:
+    def __init__(self, return_chain, schema, results):
+        self.rc = return_chain
+        self.schema = schema
+        self.results = results
+
+        self.schema_names = []
+
+        self.indexes = self.gen_indexes()
+
+    def gen_indexes(self):
+        if len(self.rc) == 0:
+            return None
+        indexes = []
+        schema_names = [name for name, ttype in self.schema]
+        schema_base_names = [name.split(".")[-1] for name, ttype in self.schema]
+        for r in self.rc:
+            ident, name = r
+            # If there is an identifier given (e.g. `MATCH (a:A)`), then we
+            # check that if one was given with the return query that it
+            # matches the one we are looking at with the current schema.
+            # That is, if our selection is `MATCH (a:A)`, where A has fields
+            # b or c, then `RETURN b, c` and `RETURN a.b, a.c` both work and
+            # do the same thing, but `RETURN a` and `RETURN t.b` do not.
+            # if (ident == alias or ident is None) and name in schema_names:
+            #     indexes.append(schema_names.index(name))
+            if ident is None:
+                if schema_base_names.count(name) > 1:
+                    raise Exception("Property name `%s` is ambiguous." % name)
+                elif name not in schema_base_names:
+                    raise Exception("Property name `%s` does not exist." % name)
+                else:
+                    indexes.append(schema_base_names.index(name))
+                    self.schema_names.append(name)
+            else:
+                key = "%s.%s" % r
+                if key not in schema_names:
+                    raise Exception("Property name `%s` does not exist." % key)
+                else:
+                    indexes.append(schema_names.index(key))
+                    self.schema_names.append(key)
+        return indexes
+
+    def __iter__(self):
+        for result in self.results:
+            if self.indexes is not None:
+                yield map(lambda i: result[i], self.indexes)
+            else:
+                yield result

--- a/graphene/query/project_stream.py
+++ b/graphene/query/project_stream.py
@@ -11,6 +11,10 @@ class ProjectStream:
         self.indexes = self.gen_indexes()
 
     def gen_indexes(self):
+        """
+        This generates the indexes of the original schema that correspond to the
+        new schema after applying projection.
+        """
         indexes = []
         if len(self.rc) == 0:
             for i, pair in enumerate(self.schema):

--- a/graphene/query/project_stream.py
+++ b/graphene/query/project_stream.py
@@ -9,36 +9,41 @@ class ProjectStream:
         self.indexes = self.gen_indexes()
 
     def gen_indexes(self):
-        if len(self.rc) == 0:
-            return None
         indexes = []
-        schema_names = [name for name, ttype in self.schema]
-        schema_base_names = [name.split(".")[-1] for name, ttype in self.schema]
-        for r in self.rc:
-            ident, name = r
-            # If there is an identifier given (e.g. `MATCH (a:A)`), then we
-            # check that if one was given with the return query that it
-            # matches the one we are looking at with the current schema.
-            # That is, if our selection is `MATCH (a:A)`, where A has fields
-            # b or c, then `RETURN b, c` and `RETURN a.b, a.c` both work and
-            # do the same thing, but `RETURN a` and `RETURN t.b` do not.
-            # if (ident == alias or ident is None) and name in schema_names:
-            #     indexes.append(schema_names.index(name))
-            if ident is None:
-                if schema_base_names.count(name) > 1:
-                    raise Exception("Property name `%s` is ambiguous." % name)
-                elif name not in schema_base_names:
-                    raise Exception("Property name `%s` does not exist." % name)
-                else:
-                    indexes.append(schema_base_names.index(name))
+        if len(self.rc) == 0:
+            for i, pair in enumerate(self.schema):
+                name, ttype = pair
+                # If this is not 1, that means there's an identifier, so we want
+                # to include this index in the return results.
+                if len(name.split(".")) > 1:
+                    indexes.append(i)
                     self.schema_names.append(name)
-            else:
-                key = "%s.%s" % r
-                if key not in schema_names:
-                    raise Exception("Property name `%s` does not exist." % key)
+        else:
+            schema_names = [name for name, ttype in self.schema]
+            schema_base_names = [name.split(".")[-1] for name, ttype in self.schema]
+            for r in self.rc:
+                ident, name = r
+                # If there is an identifier given (e.g. `MATCH (a:A)`), then we
+                # check that if one was given with the return query that it
+                # matches the one we are looking at with the current schema.
+                # That is, if our selection is `MATCH (a:A)`, where A has fields
+                # b or c, then `RETURN b, c` and `RETURN a.b, a.c` both work and
+                # do the same thing, but `RETURN a` and `RETURN t.b` do not.
+                if ident is None:
+                    if schema_base_names.count(name) > 1:
+                        raise Exception("Property name `%s` is ambiguous." % name)
+                    elif name not in schema_base_names:
+                        raise Exception("Property name `%s` does not exist." % name)
+                    else:
+                        indexes.append(schema_base_names.index(name))
+                        self.schema_names.append(name)
                 else:
-                    indexes.append(schema_names.index(key))
-                    self.schema_names.append(key)
+                    key = "%s.%s" % r
+                    if key not in schema_names:
+                        raise Exception("Property name `%s` does not exist." % key)
+                    else:
+                        indexes.append(schema_names.index(key))
+                        self.schema_names.append(key)
         return indexes
 
     def __iter__(self):

--- a/graphene/storage/intermediate/__init__.py
+++ b/graphene/storage/intermediate/__init__.py
@@ -3,3 +3,4 @@ from graphene.storage.intermediate.general_name_manager import GeneralNameManage
 from graphene.storage.intermediate.node_property_store import NodePropertyStore
 from graphene.storage.intermediate.relationship_property_store import RelationshipPropertyStore
 from graphene.storage.intermediate.node_property import NodeProperty
+from graphene.storage.intermediate.relation_property import RelationProperty

--- a/graphene/storage/intermediate/relation_property.py
+++ b/graphene/storage/intermediate/relation_property.py
@@ -1,0 +1,19 @@
+class RelationProperty:
+    def __init__(self, rel, properties, rel_type, type_name):
+        self.rel = rel
+        self.index = rel.index
+        self.properties = properties
+        self.type = rel_type
+        self.type_name = type_name
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.rel == other.rel
+        else:
+            return False
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def __str__(self):
+        return "%s%s" % (self.type_name, self.properties)

--- a/graphene/storage/intermediate/relationship_property_store.py
+++ b/graphene/storage/intermediate/relationship_property_store.py
@@ -18,8 +18,8 @@ class RelationshipPropertyStore:
 
     def __getitem__(self, key):
         cur_relationship = self.relationship_manager.get_item_at_index(key)
-        if cur_relationship is None:
-            return None
+        if cur_relationship is None or cur_relationship == GeneralStore.EOF:
+            return cur_relationship
         properties = []
         cur_prop_id = cur_relationship.propId
         while cur_prop_id != 0:

--- a/graphene/storage/storage_manager.py
+++ b/graphene/storage/storage_manager.py
@@ -512,6 +512,27 @@ class StorageManager:
         print("new rel: %s" % new_rel)
         return new_rel
 
+    def get_relation(self, index):
+        relprop = self.relprop[index]
+        if relprop is None or relprop == GeneralStore.EOF:
+            return relprop
+        rel, properties = relprop
+        rel_type = self.relTypeManager.get_item_at_index(rel.relType)
+        type_name = self.relTypeNameManager.\
+            read_name_at_index(rel_type.nameId)
+        properties = map(self.get_property_value, properties)
+        return RelationProperty(rel, properties, rel_type, type_name)
+
+    def get_relations_of_type(self, relation_type):
+        i = 1
+        while True:
+            relation = self.get_relation(i)
+            if relation == GeneralStore.EOF:
+                break
+            i += 1
+            if relation is not None and relation.type == relation_type:
+                yield relation
+
     @staticmethod
     def convert_to_value(s, given_type):
         if given_type == Property.PropertyType.bool:

--- a/graphene/traversal/__init__.py
+++ b/graphene/traversal/__init__.py
@@ -1,2 +1,3 @@
 from node_iterator import NodeIterator
+from relation_iterator import RelationIterator
 from query import Query

--- a/graphene/traversal/node_iterator.py
+++ b/graphene/traversal/node_iterator.py
@@ -27,14 +27,17 @@ class NodeIterator:
             result[name] = (props[i], tt_type)
         return result
 
+    def node_matches(self, properties):
+        # For now we assume all the queries are ANDed together.
+        # TODO: Handle actual boolean logic. Probably will involve some
+        # recursion somewhere.
+        matches = True
+        for q in self.queries:
+            if isinstance(q, Query):
+                matches = matches and q.test(self.prop_to_dict(properties))
+        return matches
+
     def __iter__(self):
-        for node in self.sm.get_nodes_of_type(self.node_type):
-            # For now we assume all the queries are ANDed together.
-            # TODO: Handle actual boolean logic. Probably will involve some
-            # recursion somewhere.
-            matches = True
-            for q in self.queries:
-                if isinstance(q, Query):
-                    matches = matches and q.test(self.prop_to_dict(node.properties))
-            if matches:
-                yield node
+        for nodeprop in self.sm.get_nodes_of_type(self.node_type):
+            if self.node_matches(nodeprop.properties):
+                yield nodeprop

--- a/graphene/traversal/node_iterator.py
+++ b/graphene/traversal/node_iterator.py
@@ -2,11 +2,11 @@ from graphene.traversal.query import Query
 from graphene.storage import *
 
 class NodeIterator:
-    def __init__(self, storage_manager, node_type, type_schema, alias=None, queries=None):
+    def __init__(self, storage_manager, match_node, schema, queries=None):
         self.sm = storage_manager
-        self.node_type = node_type
-        self.schema = type_schema
-        self.alias = alias
+        self.alias = match_node.name
+        self.node_type, self.schema = storage_manager.get_node_data(match_node.type)
+        #self.schema = schema
         if queries is not None:
             self.queries = queries
         else:
@@ -23,9 +23,8 @@ class NodeIterator:
             # duplicates
             if self.alias is not None:
                 key = "%s.%s" % (self.alias, name)
-            else:
-                key = name
-            result[key] = (props[i], tt_type)
+                result[key] = (props[i], tt_type)
+            result[name] = (props[i], tt_type)
         return result
 
     def __iter__(self):

--- a/graphene/traversal/node_iterator.py
+++ b/graphene/traversal/node_iterator.py
@@ -10,6 +10,10 @@ class NodeIterator:
         self.queries = queries[:]
 
     def prop_to_dict(self, props):
+        """
+        Converts the provided property list into a dict corresponding to the key
+        names (which may have identifiers)
+        """
         result = {}
         for i, tt_data in enumerate(self.schema):
             tt, name, tt_type = tt_data
@@ -25,6 +29,10 @@ class NodeIterator:
         return result
 
     def node_matches(self, properties):
+        """
+        Tests whether the provided properties (which came from a node) are
+        matched by the queries the iterator was provided with.
+        """
         # For now we assume all the queries are ANDed together.
         # TODO: Handle actual boolean logic. Probably will involve some
         # recursion somewhere.

--- a/graphene/traversal/node_iterator.py
+++ b/graphene/traversal/node_iterator.py
@@ -2,15 +2,12 @@ from graphene.traversal.query import Query
 from graphene.storage import *
 
 class NodeIterator:
-    def __init__(self, storage_manager, match_node, schema, queries=None):
+    def __init__(self, storage_manager, match_node, schema, queries=()):
         self.sm = storage_manager
         self.alias = match_node.name
         self.node_type, self.schema = storage_manager.get_node_data(match_node.type)
-        #self.schema = schema
-        if queries is not None:
-            self.queries = queries
-        else:
-            self.queries = ()
+        # copy to ensure tuple in argument default is not modified
+        self.queries = queries[:]
 
     def prop_to_dict(self, props):
         result = {}

--- a/graphene/traversal/query.py
+++ b/graphene/traversal/query.py
@@ -28,6 +28,12 @@ class Query:
             return value < self.value
         return False
 
+    def __repr__(self):
+        if self.ident is not None:
+            return "Query[%s.%s %s %s]" % (self.ident, self.name, self.oper, self.value)
+        else:
+            return "Query[%s %s %s]" % (self.name, self.oper, self.value)
+
     @staticmethod
     def parse_chain(storage_manager, chain, type_schema):
         qc = []

--- a/graphene/traversal/query.py
+++ b/graphene/traversal/query.py
@@ -34,6 +34,18 @@ class Query:
         else:
             return "Query[%s %s %s]" % (self.name, self.oper, self.value)
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return (self.ident == other.ident) and \
+                   (self.name == other.name) and \
+                   (self.oper == other.oper) and \
+                   (self.value == other.value)
+        else:
+            return False
+
+    def __ne__(self, other):
+        return not (self == other)
+
     @staticmethod
     def parse_chain(storage_manager, chain, type_schema):
         qc = []
@@ -41,7 +53,7 @@ class Query:
             if type(q) == tuple:
                 # actual query
                 ident, name, oper, value = q
-                tt = filter(lambda t: t[0] == name or t[0].split(".")[1] == name, type_schema)
+                tt = filter(lambda t: t[0] == name or t[0].split(".")[-1] == name, type_schema)
                 if len(tt) == 0:
                     # no such named property
                     raise Exception("%s is not a valid property name." % name)

--- a/graphene/traversal/query.py
+++ b/graphene/traversal/query.py
@@ -8,6 +8,10 @@ class Query:
         self.value = value
 
     def test(self, prop_dict):
+        """
+        Test the current query against a dictionary of properties, which
+        correspond to some node we are trying to match with.
+        """
         if self.ident is not None:
             key = "%s.%s" % (self.ident, self.name)
         else:
@@ -51,6 +55,12 @@ class Query:
 
     @staticmethod
     def parse_chain(storage_manager, chain, type_schema):
+        """
+        Parses a chain of queries from tuples of basic information (i.e. the
+        identifier, name of the property, the operator, and the value tested)
+        given the schema they should apply to. Returns a list of Query objects
+        that can be used for testing later.
+        """
         qc = []
         for q in chain:
             if type(q) == tuple:

--- a/graphene/traversal/query.py
+++ b/graphene/traversal/query.py
@@ -29,18 +29,17 @@ class Query:
         return False
 
     @staticmethod
-    def parse_chain(storage_manager, chain, type_schema, alias=None):
+    def parse_chain(storage_manager, chain, type_schema):
         qc = []
         for q in chain:
             if type(q) == tuple:
                 # actual query
                 ident, name, oper, value = q
-                ident = ident or alias
-                tt = filter(lambda t: t[1] == name, type_schema)
+                tt = filter(lambda t: t[0] == name or t[0].split(".")[1] == name, type_schema)
                 if len(tt) == 0:
                     # no such named property
                     raise Exception("%s is not a valid property name." % name)
-                ttype = tt[0][2]
+                ttype = tt[0][1]
                 qc.append(Query(ident, name, oper, storage_manager.convert_to_value(value, ttype)))
             else:
                 qc.append(q)

--- a/graphene/traversal/query.py
+++ b/graphene/traversal/query.py
@@ -1,3 +1,5 @@
+from graphene.errors import *
+
 class Query:
     def __init__(self, ident, name, oper, value):
         self.ident = ident
@@ -13,7 +15,7 @@ class Query:
         try:
             value, tt = prop_dict[key]
         except KeyError:
-            raise Exception("%s is not a valid property name." % key)
+            raise NonexistentPropertyException("%s is not a valid property name." % key)
         if self.oper == '=':
             return value == self.value
         if self.oper == '!=':
@@ -26,6 +28,7 @@ class Query:
             return value <= self.value
         if self.oper == '<':
             return value < self.value
+        # TODO: This should probably throw an error...
         return False
 
     def __repr__(self):
@@ -53,10 +56,11 @@ class Query:
             if type(q) == tuple:
                 # actual query
                 ident, name, oper, value = q
+                # check that the named property exists
+                # TODO: Check if this is actually correct...
                 tt = filter(lambda t: t[0] == name or t[0].split(".")[-1] == name, type_schema)
                 if len(tt) == 0:
-                    # no such named property
-                    raise Exception("%s is not a valid property name." % name)
+                    raise NonexistentPropertyException("%s is not a valid property name." % name)
                 ttype = tt[0][1]
                 qc.append(Query(ident, name, oper, storage_manager.convert_to_value(value, ttype)))
             else:

--- a/graphene/traversal/relation_iterator.py
+++ b/graphene/traversal/relation_iterator.py
@@ -3,15 +3,12 @@ from graphene.traversal.node_iterator import NodeIterator
 from graphene.storage import *
 
 class RelationIterator:
-    def __init__(self, storage_manager, match_rel, left_child, right_child, schema, queries=None):
+    def __init__(self, storage_manager, match_rel, left_child, right_child, schema, queries=()):
         self.sm = storage_manager
         self.alias = match_rel.name
         self.rel_type, self.schema = storage_manager.get_relationship_data(match_rel.type)
-        #self.schema = schema
-        if queries is not None:
-            self.queries = queries
-        else:
-            self.queries = ()
+        # copy to ensure tuple in argument default is not modified
+        self.queries = queries[:]
         self.left = left_child
         self.right = right_child
 

--- a/graphene/traversal/relation_iterator.py
+++ b/graphene/traversal/relation_iterator.py
@@ -13,6 +13,10 @@ class RelationIterator:
         self.right = right_child
 
     def prop_to_dict(self, props):
+        """
+        Converts the provided property list into a dict corresponding to the key
+        names (which may have identifiers)
+        """
         result = {}
         for i, tt_data in enumerate(self.schema):
             tt, name, tt_type = tt_data

--- a/graphene/traversal/relation_iterator.py
+++ b/graphene/traversal/relation_iterator.py
@@ -1,0 +1,74 @@
+from graphene.traversal.query import Query
+from graphene.traversal.node_iterator import NodeIterator
+from graphene.storage import *
+
+class RelationIterator:
+    def __init__(self, storage_manager, match_rel, left_child, right_child, schema, queries=None):
+        self.sm = storage_manager
+        self.alias = match_rel.name
+        self.rel_type, self.schema = storage_manager.get_relationship_data(match_rel.type)
+        #self.schema = schema
+        if queries is not None:
+            self.queries = queries
+        else:
+            self.queries = ()
+        self.left = left_child
+        self.right = right_child
+
+    def prop_to_dict(self, props):
+        result = {}
+        for i, tt_data in enumerate(self.schema):
+            tt, name, tt_type = tt_data
+            # If there is an alias, create a key from it; i.e. if the type
+            # identifier is t, then t.a works.
+
+            # TODO: Handle multiple scenarios with multiple aliases; also notice
+            # duplicates
+            if self.alias is not None:
+                key = "%s.%s" % (self.alias, name)
+                result[key] = (props[i], tt_type)
+            result[name] = (props[i], tt_type)
+        return result
+
+    def __iter__(self):
+        for relprop in self.sm.get_relations_of_type(self.rel_type):
+            rel = relprop.rel
+            # Make sure relation matches queries provided
+            matches = True
+            for q in self.queries:
+                if isinstance(q, Query):
+                    matches = matches and q.test(self.prop_to_dict(relprop.properties))
+            if not matches:
+                continue
+
+            # Right side will always be a NodeIterator (we branch to the left)
+            right_node = self.sm.get_node(rel.secondNodeId)
+            left_node = self.sm.get_node(rel.firstNodeId)
+
+            # If the right node is not of the correct type or wasn't matched by
+            # the right side's iteration, then this doesn't match
+            if right_node.node.nodeType != self.right.node_type.index \
+                or right_node not in self.right:
+                continue
+
+            # If the left is a NodeIterator, our original request was one degree
+            # of separation
+            if isinstance(self.left, NodeIterator):
+                # Check the left node's type
+                if left_node.node.nodeType != self.left.node_type.index:
+                    continue
+                # Check that the left node existed in the left result iterator.
+                # If it did, return properties and the right node (so that
+                # future chains can determine whether their left node
+                # corresponds to this right node)
+                if left_node in self.left:
+                    yield (left_node.properties + relprop.properties + \
+                            right_node.properties, right_node)
+            # Otherwise, we already chained from something else, so we just
+            # check that the left node is the right node of something on the
+            # left side of the iteration
+            else:
+                for props, right in self.left:
+                    if left_node.node == right.node:
+                        yield (props + relprop.properties + \
+                                right_node.properties, right_node)

--- a/graphene/traversal/relation_iterator.py
+++ b/graphene/traversal/relation_iterator.py
@@ -48,7 +48,7 @@ class RelationIterator:
             # If the right node is not of the correct type or wasn't matched by
             # the right side's iteration, then this doesn't match
             if right_node.node.nodeType != self.right.node_type.index \
-                or right_node not in self.right:
+                or not self.right.node_matches(right_node.properties):
                 continue
 
             # If the left is a NodeIterator, our original request was one degree
@@ -61,7 +61,7 @@ class RelationIterator:
                 # If it did, return properties and the right node (so that
                 # future chains can determine whether their left node
                 # corresponds to this right node)
-                if left_node in self.left:
+                if self.left.node_matches(left_node.properties):
                     yield (left_node.properties + relprop.properties + \
                             right_node.properties, right_node)
             # Otherwise, we already chained from something else, so we just

--- a/tests/commands/test_match_command.py
+++ b/tests/commands/test_match_command.py
@@ -106,6 +106,15 @@ class TestMatchCommand(unittest.TestCase):
         self.assertTrue(self.lists_equal_unordered(ret_vals, exp_vals))
 
     def test_match_where_badname(self):
+        # No identifier, property name doesn't exist
         cmd = self.server.parseString("MATCH (t:T) WHERE b = 1;")[0]
+        with self.assertRaises(Exception):
+            cmd.execute(self.sm, self.devnull)
+        # Correct identifier, property name still doesn't exist
+        cmd = self.server.parseString("MATCH (t:T) WHERE t.b = 1;")[0]
+        with self.assertRaises(Exception):
+            cmd.execute(self.sm, self.devnull)
+        # Incorrect identifier despite correct property name
+        cmd = self.server.parseString("MATCH (t:T) WHERE t2.a = 1;")[0]
         with self.assertRaises(Exception):
             cmd.execute(self.sm, self.devnull)

--- a/tests/query/test_planner.py
+++ b/tests/query/test_planner.py
@@ -8,31 +8,39 @@ from graphene.errors import *
 from graphene.traversal import Query
 
 class TestQueryPlanner(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         GrapheneStore.TESTING = True
         graphene_store = GrapheneStore()
         graphene_store.remove_test_datafiles()
-        self.server = GrapheneServer()
-        self.sm = self.server.storage_manager
+        cls.server = GrapheneServer()
+        cls.sm = cls.server.storage_manager
 
-        self.server.doCommands("CREATE TYPE T ( a: int );", False)
-        self.server.doCommands("INSERT NODE T(1), T(2), T(3), T(4), T(5);", False)
+        cls.server.doCommands("CREATE TYPE T ( a: int );", False)
+        cls.server.doCommands("INSERT NODE T(1), T(2), T(3), T(4), T(5);", False)
+        cls.server.doCommands("CREATE TYPE S ( c: int );", False)
+        cls.server.doCommands("INSERT NODE S(7);", False)
 
-        self.server.doCommands("CREATE RELATION R ( b: int );", False)
-        self.server.doCommands("INSERT RELATION T(a=1)-[R(2)]->T(a=2);")
-        self.server.doCommands("INSERT RELATION T(a=1)-[R(3)]->T(a=3);")
-        self.server.doCommands("INSERT RELATION T(a=2)-[R(6)]->T(a=3);")
-        self.server.doCommands("INSERT RELATION T(a=3)-[R(12)]->T(a=4);")
-        self.server.doCommands("INSERT RELATION T(a=3)-[R(15)]->T(a=5);")
+        cls.server.doCommands("CREATE RELATION R ( b: int );", False)
+        cls.server.doCommands("INSERT RELATION T(a=1)-[R(2)]->T(a=2);")
+        cls.server.doCommands("INSERT RELATION T(a=1)-[R(3)]->T(a=3);")
+        cls.server.doCommands("INSERT RELATION T(a=2)-[R(6)]->T(a=3);")
+        cls.server.doCommands("INSERT RELATION T(a=3)-[R(12)]->T(a=4);")
+        cls.server.doCommands("INSERT RELATION T(a=3)-[R(15)]->T(a=5);")
+        cls.server.doCommands("INSERT RELATION S(c=7)-[R(0)]->T(a=5);")
 
-        self.planner = QueryPlanner(self.sm)
+        cls.planner = QueryPlanner(cls.sm)
 
-    def tearDown(self):
+    @classmethod
+    def tearDown(cls):
         """
         Clean the database so that the tests are independent of one another
         """
         graphene_store = GrapheneStore()
         graphene_store.remove_test_datafiles()
+
+    def assertListEqualUnsorted(self, given, expected):
+        self.assertListEqual(sorted(given), sorted(expected))
 
     def lists_equal_unordered(self, values, expected):
         tvalues = map(tuple, values)
@@ -187,14 +195,14 @@ class TestQueryPlanner(unittest.TestCase):
         # Without identifier
         exp_schema = ['a']
         exp_vals = [(1,), (2,), (3,), (4,), (5,)]
-        schema, results = self.planner.execute((MatchNode(None, "T"),), (), ())
+        schema, results = self.planner.execute((MatchNode(None, "T"),), None, None)
         self.assertListEqual(schema, exp_schema)
         self.assertTrue(self.lists_equal_unordered(results, exp_vals))
 
         # With identifier
         exp_schema = ['t.a']
         exp_vals = [(1,), (2,), (3,), (4,), (5,)]
-        schema, results = self.planner.execute((MatchNode("t", "T"),), (), ())
+        schema, results = self.planner.execute((MatchNode("t", "T"),), None, None)
         self.assertListEqual(schema, exp_schema)
         self.assertTrue(self.lists_equal_unordered(results, exp_vals))
 
@@ -207,56 +215,132 @@ class TestQueryPlanner(unittest.TestCase):
         # (t:T)-[r:R]->(t2:T)
         exp_schema = ['t.a', 'r.b', 't2.a']
         exp_vals = [(1,2,2), (1,3,3), (2,6,3), (3,12,4), (3,15,5)]
-        schema, results = self.planner.execute((n1, r, n2), (), ())
+        schema, results = self.planner.execute((n1, r, n2), None, None)
         self.assertListEqual(schema, exp_schema)
         self.assertTrue(self.lists_equal_unordered(results, exp_vals))
 
         # (t:T)-[R]->(t2:T)
         exp_schema = ['t.a', 't2.a']
         exp_vals = [(1,2), (1,3), (2,3), (3,4), (3,5)]
-        schema, results = self.planner.execute((n1, rni, n2), (), ())
+        schema, results = self.planner.execute((n1, rni, n2), None, None)
         self.assertListEqual(schema, exp_schema)
         self.assertTrue(self.lists_equal_unordered(results, exp_vals))
 
         # (t:T)-[R]->(T)
         exp_schema = ['t.a']
         exp_vals = [(1,), (1,), (2,), (3,), (3,)]
-        schema, results = self.planner.execute((n1, rni, n2ni), (), ())
+        schema, results = self.planner.execute((n1, rni, n2ni), None, None)
         self.assertListEqual(schema, exp_schema)
         self.assertTrue(self.lists_equal_unordered(results, exp_vals))
 
         # (T)-[R]->(t2:T)
         exp_schema = ['t2.a']
         exp_vals = [(2,), (3,), (3,), (4,), (5,)]
-        schema, results = self.planner.execute((n1ni, rni, n2), (), ())
+        schema, results = self.planner.execute((n1ni, rni, n2), None, None)
         self.assertListEqual(schema, exp_schema)
         self.assertTrue(self.lists_equal_unordered(results, exp_vals))
 
         # (T)-[r:R]->(T)
         exp_schema = ['r.b']
         exp_vals = [(2,), (3,), (6,), (12,), (15,)]
-        schema, results = self.planner.execute((n1ni, r, n2ni), (), ())
+        schema, results = self.planner.execute((n1ni, r, n2ni), None, None)
         self.assertListEqual(schema, exp_schema)
         self.assertTrue(self.lists_equal_unordered(results, exp_vals))
 
         # (t:T)-[r:R]->(T)
         exp_schema = ['t.a', 'r.b']
         exp_vals = [(1,2), (1,3), (2,6), (3,12), (3,15)]
-        schema, results = self.planner.execute((n1, r, n2ni), (), ())
+        schema, results = self.planner.execute((n1, r, n2ni), None, None)
         self.assertListEqual(schema, exp_schema)
         self.assertTrue(self.lists_equal_unordered(results, exp_vals))
 
     def test_execute_multi_relation(self):
-        assert True
+        #ni = no ident
+        n1, n1ni = MatchNode("t", "T"), MatchNode(None, "T")
+        n2, n2ni = MatchNode("t2", "T"), MatchNode(None, "T")
+        n3, n3ni = MatchNode("t3", "T"), MatchNode(None, "T")
+        r, rni = MatchRelation("r", "R"), MatchRelation(None, "R")
+        r2, r2ni = MatchRelation("r2", "R"), MatchRelation(None, "R")
+
+        # (t:T)-[r:R]->(t2:T)-[r2:R]->(t3:T)
+        exp_schema = ['t.a', 'r.b', 't2.a', 'r2.b', 't3.a']
+        exp_vals = [[1,2,2,6,3], [1,3,3,12,4], [1,3,3,15,5], [2,6,3,12,4], [2,6,3,15,5]]
+        schema, results = self.planner.execute((n1, r, n2, r2, n3), None, None)
+        self.assertListEqual(schema, exp_schema)
+        self.assertListEqualUnsorted(results, exp_vals)
+
+        # (t:T)-[R]->(T)-[R]->(t3:T)
+        exp_schema = ['t.a', 't3.a']
+        exp_vals = [[1,3], [1,4], [1,5], [2,4], [2,5]]
+        schema, results = self.planner.execute((n1, rni, n2ni, r2ni, n3), None, None)
+        self.assertListEqual(schema, exp_schema)
+        self.assertListEqualUnsorted(results, exp_vals)
 
     def test_execute_with_query(self):
-        assert True
+        #ni = no ident
+        n1, n1ni = MatchNode("t", "T"), MatchNode(None, "T")
+        n2, n2ni = MatchNode("t2", "T"), MatchNode(None, "T")
+        n3, n3ni = MatchNode("t3", "T"), MatchNode(None, "T")
+        r, rni = MatchRelation("r", "R"), MatchRelation(None, "R")
+        r2, r2ni = MatchRelation("r2", "R"), MatchRelation(None, "R")
+
+        # (t:T)-[r:R]->(t2:T)-[r2:R]->(t3:T)
+        exp_schema = ['t.a', 'r.b', 't2.a', 'r2.b', 't3.a']
+        # node queries
+        exp_vals = [[1,2,2,6,3], [1,3,3,12,4], [1,3,3,15,5]]
+        schema, results = self.planner.execute((n1, r, n2, r2, n3), (('t','a','=','1'),), None)
+        self.assertListEqual(schema, exp_schema)
+        self.assertListEqualUnsorted(results, exp_vals)
+
+        exp_vals = [[1,3,3,12,4], [1,3,3,15,5], [2,6,3,12,4], [2,6,3,15,5]]
+        schema, results = self.planner.execute((n1, r, n2, r2, n3), (('t2','a','=','3'),), None)
+        self.assertListEqualUnsorted(results, exp_vals)
+
+        exp_vals = [[1,3,3,12,4], [2,6,3,12,4]]
+        schema, results = self.planner.execute((n1, r, n2, r2, n3), (('t3','a','=','4'),), None)
+        self.assertListEqualUnsorted(results, exp_vals)
+
+        # relation queries
+        exp_vals = [[1,2,2,6,3]]
+        schema, results = self.planner.execute((n1, r, n2, r2, n3), (('r','b','=','2'),), None)
+        self.assertListEqualUnsorted(results, exp_vals)
 
     def test_execute_with_return(self):
-        assert True
+        #ni = no ident
+        n1, n1ni = MatchNode("t", "T"), MatchNode(None, "T")
+        n2, n2ni = MatchNode("t2", "T"), MatchNode(None, "T")
+        n3, n3ni = MatchNode("t3", "T"), MatchNode(None, "T")
+        r, rni = MatchRelation("r", "R"), MatchRelation(None, "R")
+        r2, r2ni = MatchRelation("r2", "R"), MatchRelation(None, "R")
+
+        # (t:T)-[r:R]->(t2:T)-[r2:R]->(t3:T) RETURN t.a
+        exp_schema = ['t.a']
+        # node queries
+        exp_vals = [[1],[1],[1],[2],[2]]
+        schema, results = self.planner.execute((n1, r, n2, r2, n3), None, (('t', 'a'),))
+        self.assertListEqual(schema, exp_schema)
+        self.assertListEqualUnsorted(results, exp_vals)
 
     def test_execute_with_ambiguous_names(self):
-        assert True
+        #ni = no ident
+        n1, n1ni = MatchNode("t", "T"), MatchNode(None, "T")
+        n2, n2ni = MatchNode("t2", "T"), MatchNode(None, "T")
+        n3, n3ni = MatchNode("t3", "T"), MatchNode(None, "T")
+        r, rni = MatchRelation("r", "R"), MatchRelation(None, "R")
+        r2, r2ni = MatchRelation("r2", "R"), MatchRelation(None, "R")
+
+        # (t:T)-[r:R]->(t2:T)-[r2:R]->(t3:T) WHERE a = 1
+        with self.assertRaises(AmbiguousPropertyException):
+            self.planner.execute((n1, r, n2, r2, n3), ((None, 'a', '=', '1'),), None)
+
+        # (t:T)-[r:R]->(t2:T)-[r2:R]->(t3:T) RETURN a
+        with self.assertRaises(AmbiguousPropertyException):
+            self.planner.execute((n1, r, n2, r2, n3), None, ((None, 'a'),))
 
     def test_execute_with_duplicate_names(self):
-        assert True
+        #ni = no ident
+        n1, n1ni = MatchNode("t", "T"), MatchNode(None, "T")
+        r, rni = MatchRelation("r", "R"), MatchRelation(None, "R")
+
+        with self.assertRaises(DuplicatePropertyException):
+            self.planner.execute((n1, r, n1), None, None)

--- a/tests/query/test_planner.py
+++ b/tests/query/test_planner.py
@@ -1,0 +1,262 @@
+import unittest
+
+from graphene.server.server import GrapheneServer
+from graphene.query.planner import QueryPlanner
+from graphene.storage import (StorageManager, GrapheneStore, Property)
+from graphene.expressions import *
+from graphene.errors import *
+from graphene.traversal import Query
+
+class TestQueryPlanner(unittest.TestCase):
+    def setUp(self):
+        GrapheneStore.TESTING = True
+        graphene_store = GrapheneStore()
+        graphene_store.remove_test_datafiles()
+        self.server = GrapheneServer()
+        self.sm = self.server.storage_manager
+
+        self.server.doCommands("CREATE TYPE T ( a: int );", False)
+        self.server.doCommands("INSERT NODE T(1), T(2), T(3), T(4), T(5);", False)
+
+        self.server.doCommands("CREATE RELATION R ( b: int );", False)
+        self.server.doCommands("INSERT RELATION T(a=1)-[R(2)]->T(a=2);")
+        self.server.doCommands("INSERT RELATION T(a=1)-[R(3)]->T(a=3);")
+        self.server.doCommands("INSERT RELATION T(a=2)-[R(6)]->T(a=3);")
+        self.server.doCommands("INSERT RELATION T(a=3)-[R(12)]->T(a=4);")
+        self.server.doCommands("INSERT RELATION T(a=3)-[R(15)]->T(a=5);")
+
+        self.planner = QueryPlanner(self.sm)
+
+    def tearDown(self):
+        """
+        Clean the database so that the tests are independent of one another
+        """
+        graphene_store = GrapheneStore()
+        graphene_store.remove_test_datafiles()
+
+    def lists_equal_unordered(self, values, expected):
+        tvalues = map(tuple, values)
+        for tv in tvalues:
+            try:
+                idx = expected.index(tv)
+            except ValueError:
+                # not in list!
+                return False
+            del expected[idx]
+        if len(expected) > 0:
+            # didn't hit everything in expected list
+            return False
+        return True
+
+    def test_get_schema(self):
+        #ni = no ident
+        n1, n1ni = MatchNode("t", "T"), MatchNode(None, "T")
+        n2, n2ni = MatchNode("t2", "T"), MatchNode(None, "T")
+        r, rni = MatchRelation("r", "R"), MatchRelation(None, "R")
+
+        # (T)
+        self.assertListEqual(self.planner.get_schema((n1ni,)),
+            [('a', Property.PropertyType.int)])
+
+        # (t:T)
+        self.assertListEqual(self.planner.get_schema((n1,)),
+            [('t.a', Property.PropertyType.int)])
+
+        # (T)-[r:R]->(T) => no error, because duplicates will be stripped anyway
+        self.assertListEqual(self.planner.get_schema((n1ni, r, n2ni), True),
+            [('a', Property.PropertyType.int), ('r.b', Property.PropertyType.int),
+            ('a', Property.PropertyType.int)])
+
+        # (T)-[R]->(T) => error (duplicate), if the set is the full schema
+        with self.assertRaises(DuplicatePropertyException):
+            self.planner.get_schema((n1ni, rni, n2ni), True)
+
+        # (T)-[R]->(T) => no error, if the set is not the full set (subset, so
+        # anything not identified will be stripped later)
+        self.assertListEqual(self.planner.get_schema((n1ni, rni, n2ni), False),
+            [('a', Property.PropertyType.int), ('b', Property.PropertyType.int),
+            ('a', Property.PropertyType.int)])
+
+        # (t:T)-[R]->(t:T) => error (duplicate), same identifier
+        with self.assertRaises(DuplicatePropertyException):
+            self.planner.get_schema((n1, r, n1))
+
+    def test_check_query_single_node(self):
+        nc = (MatchNode("t", "T"),)
+
+        # With identifier
+        qc = (('t', 'a', '=', '1'),)
+        try:
+            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+        except Exception:
+            self.fail("check_query raised an Exception unexpectedly.")
+
+        # Without identifier
+        qc = ((None, 'a', '=', '1'),)
+        try:
+            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+        except Exception:
+            self.fail("check_query raised an Exception unexpectedly.")
+
+        # No such property
+        qc = ((None, 'b', '=', '1'),)
+        with self.assertRaises(NonexistentPropertyException):
+            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+
+        # No such identifier
+        qc = (('s', 'a', '=', '1'),)
+        with self.assertRaises(NonexistentPropertyException):
+            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+
+    def test_check_query_relations(self):
+        nc = (MatchNode("t", "T"), MatchRelation("r", "R"), MatchNode("t2", "T"))
+
+        # With identifier
+        qc = (('t', 'a', '=', '1'),)
+        try:
+            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+        except Exception:
+            self.fail("check_query raised an Exception unexpectedly.")
+
+        qc = (('r', 'b', '=', '1'),)
+        try:
+            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+        except Exception:
+            self.fail("check_query raised an Exception unexpectedly.")
+
+        # Without identifier, ambiguous
+        qc = ((None, 'a', '=', '1'),)
+        with self.assertRaises(AmbiguousPropertyException):
+            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+
+        # Without identifier, unambiguous
+        qc = ((None, 'b', '=', '1'),)
+        try:
+            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+        except Exception:
+            self.fail("check_query raised an Exception unexpectedly.")
+
+        # No such identifier
+        qc = (('s', 'a', '=', '1'),)
+        with self.assertRaises(NonexistentPropertyException):
+            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+
+    def test_reduce_query_chain(self):
+        #ni = no ident
+        n1, n1ni = MatchNode("t", "T"), MatchNode(None, "T")
+        n2, n2ni = MatchNode("t2", "T"), MatchNode(None, "T")
+        r, rni = MatchRelation("r", "R"), MatchRelation(None, "R")
+
+        qc = (('t', 'a', '=', '1'), ('r', 'b', '>', '0'))
+        expected = Query.parse_chain(self.sm, (('t', 'a', '=', '1'),), self.planner.get_schema((n1,)))
+        result = self.planner.reduce_query_chain(qc, self.planner.get_schema((n1, r, n2ni)), 't')
+        self.assertListEqual(result, expected)
+
+        expected = Query.parse_chain(self.sm, (('r', 'b', '>', '0'),), self.planner.get_schema((r,)))
+        result = self.planner.reduce_query_chain(qc, self.planner.get_schema((n1, r, n2ni)), 'r')
+        self.assertListEqual(result, expected)
+
+        expected = []
+        result = self.planner.reduce_query_chain(qc, self.planner.get_schema((n1, r, n2ni)))
+        self.assertListEqual(result, expected)
+
+        qc = ((None, 'a', '=', '1'), (None, 'b', '>', '0'))
+        expected = Query.parse_chain(self.sm, ((None, 'b', '>', '0'),), self.planner.get_schema((r,)))
+        result = self.planner.reduce_query_chain(qc, self.planner.get_schema((r,)))
+        self.assertListEqual(result, expected)
+
+        # Note that this does not handle ambiguous names... check_query does
+        qc = ((None, 'a', '=', '1'), (None, 'b', '>', '0'))
+        expected = Query.parse_chain(self.sm, ((None, 'a', '=', '1'), (None, 'b', '>', '0')), self.planner.get_schema((n1, r, n2)))
+        result = self.planner.reduce_query_chain(qc, self.planner.get_schema((n1, r, n2)))
+        self.assertListEqual(result, expected)
+
+        # Does handle nonexistent properties though!
+        qc = ((None, 'c', '=', '1'),)
+        with self.assertRaises(NonexistentPropertyException):
+            self.planner.reduce_query_chain(qc, self.planner.get_schema((n1, r, n2)), throw=True)
+
+        # Check error suppression
+        qc = ((None, 'c', '=', '1'),)
+        try:
+            self.planner.reduce_query_chain(qc, self.planner.get_schema((n1, r, n2)), throw=False)
+        except Exception:
+            self.fail("reduce_query_chain threw error despite suppression being on")
+
+    def test_execute_only_nodes(self):
+        # Without identifier
+        exp_schema = ['a']
+        exp_vals = [(1,), (2,), (3,), (4,), (5,)]
+        schema, results = self.planner.execute((MatchNode(None, "T"),), (), ())
+        self.assertListEqual(schema, exp_schema)
+        self.assertTrue(self.lists_equal_unordered(results, exp_vals))
+
+        # With identifier
+        exp_schema = ['t.a']
+        exp_vals = [(1,), (2,), (3,), (4,), (5,)]
+        schema, results = self.planner.execute((MatchNode("t", "T"),), (), ())
+        self.assertListEqual(schema, exp_schema)
+        self.assertTrue(self.lists_equal_unordered(results, exp_vals))
+
+    def test_execute_one_relation(self):
+        #ni = no ident
+        n1, n1ni = MatchNode("t", "T"), MatchNode(None, "T")
+        n2, n2ni = MatchNode("t2", "T"), MatchNode(None, "T")
+        r, rni = MatchRelation("r", "R"), MatchRelation(None, "R")
+
+        # (t:T)-[r:R]->(t2:T)
+        exp_schema = ['t.a', 'r.b', 't2.a']
+        exp_vals = [(1,2,2), (1,3,3), (2,6,3), (3,12,4), (3,15,5)]
+        schema, results = self.planner.execute((n1, r, n2), (), ())
+        self.assertListEqual(schema, exp_schema)
+        self.assertTrue(self.lists_equal_unordered(results, exp_vals))
+
+        # (t:T)-[R]->(t2:T)
+        exp_schema = ['t.a', 't2.a']
+        exp_vals = [(1,2), (1,3), (2,3), (3,4), (3,5)]
+        schema, results = self.planner.execute((n1, rni, n2), (), ())
+        self.assertListEqual(schema, exp_schema)
+        self.assertTrue(self.lists_equal_unordered(results, exp_vals))
+
+        # (t:T)-[R]->(T)
+        exp_schema = ['t.a']
+        exp_vals = [(1,), (1,), (2,), (3,), (3,)]
+        schema, results = self.planner.execute((n1, rni, n2ni), (), ())
+        self.assertListEqual(schema, exp_schema)
+        self.assertTrue(self.lists_equal_unordered(results, exp_vals))
+
+        # (T)-[R]->(t2:T)
+        exp_schema = ['t2.a']
+        exp_vals = [(2,), (3,), (3,), (4,), (5,)]
+        schema, results = self.planner.execute((n1ni, rni, n2), (), ())
+        self.assertListEqual(schema, exp_schema)
+        self.assertTrue(self.lists_equal_unordered(results, exp_vals))
+
+        # (T)-[r:R]->(T)
+        exp_schema = ['r.b']
+        exp_vals = [(2,), (3,), (6,), (12,), (15,)]
+        schema, results = self.planner.execute((n1ni, r, n2ni), (), ())
+        self.assertListEqual(schema, exp_schema)
+        self.assertTrue(self.lists_equal_unordered(results, exp_vals))
+
+        # (t:T)-[r:R]->(T)
+        exp_schema = ['t.a', 'r.b']
+        exp_vals = [(1,2), (1,3), (2,6), (3,12), (3,15)]
+        schema, results = self.planner.execute((n1, r, n2ni), (), ())
+        self.assertListEqual(schema, exp_schema)
+        self.assertTrue(self.lists_equal_unordered(results, exp_vals))
+
+    def test_execute_multi_relation(self):
+        assert True
+
+    def test_execute_with_query(self):
+        assert True
+
+    def test_execute_with_return(self):
+        assert True
+
+    def test_execute_with_ambiguous_names(self):
+        assert True
+
+    def test_execute_with_duplicate_names(self):
+        assert True

--- a/tests/query/test_planner.py
+++ b/tests/query/test_planner.py
@@ -95,26 +95,26 @@ class TestQueryPlanner(unittest.TestCase):
         # With identifier
         qc = (('t', 'a', '=', '1'),)
         try:
-            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+            self.planner.check_query(self.planner.get_schema(nc), qc)
         except Exception:
             self.fail("check_query raised an Exception unexpectedly.")
 
         # Without identifier
         qc = ((None, 'a', '=', '1'),)
         try:
-            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+            self.planner.check_query(self.planner.get_schema(nc), qc)
         except Exception:
             self.fail("check_query raised an Exception unexpectedly.")
 
         # No such property
         qc = ((None, 'b', '=', '1'),)
         with self.assertRaises(NonexistentPropertyException):
-            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+            self.planner.check_query(self.planner.get_schema(nc), qc)
 
         # No such identifier
         qc = (('s', 'a', '=', '1'),)
         with self.assertRaises(NonexistentPropertyException):
-            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+            self.planner.check_query(self.planner.get_schema(nc), qc)
 
     def test_check_query_relations(self):
         nc = (MatchNode("t", "T"), MatchRelation("r", "R"), MatchNode("t2", "T"))
@@ -122,32 +122,32 @@ class TestQueryPlanner(unittest.TestCase):
         # With identifier
         qc = (('t', 'a', '=', '1'),)
         try:
-            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+            self.planner.check_query(self.planner.get_schema(nc), qc)
         except Exception:
             self.fail("check_query raised an Exception unexpectedly.")
 
         qc = (('r', 'b', '=', '1'),)
         try:
-            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+            self.planner.check_query(self.planner.get_schema(nc), qc)
         except Exception:
             self.fail("check_query raised an Exception unexpectedly.")
 
         # Without identifier, ambiguous
         qc = ((None, 'a', '=', '1'),)
         with self.assertRaises(AmbiguousPropertyException):
-            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+            self.planner.check_query(self.planner.get_schema(nc), qc)
 
         # Without identifier, unambiguous
         qc = ((None, 'b', '=', '1'),)
         try:
-            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+            self.planner.check_query(self.planner.get_schema(nc), qc)
         except Exception:
             self.fail("check_query raised an Exception unexpectedly.")
 
         # No such identifier
         qc = (('s', 'a', '=', '1'),)
         with self.assertRaises(NonexistentPropertyException):
-            self.planner.check_query(self.planner.get_schema(nc), nc, qc)
+            self.planner.check_query(self.planner.get_schema(nc), qc)
 
     def test_reduce_query_chain(self):
         #ni = no ident

--- a/tests/query/test_planner.py
+++ b/tests/query/test_planner.py
@@ -32,7 +32,7 @@ class TestQueryPlanner(unittest.TestCase):
         cls.planner = QueryPlanner(cls.sm)
 
     @classmethod
-    def tearDown(cls):
+    def tearDownClass(cls):
         """
         Clean the database so that the tests are independent of one another
         """

--- a/tests/query/test_project_stream.py
+++ b/tests/query/test_project_stream.py
@@ -1,0 +1,96 @@
+import unittest
+
+from graphene.server.server import GrapheneServer
+from graphene.query.project_stream import ProjectStream
+from graphene.storage import (StorageManager, GrapheneStore, Property)
+from graphene.expressions import *
+from graphene.errors import *
+from graphene.traversal import Query
+
+class TestProjectStream(unittest.TestCase):
+    def test_all_identified_no_project(self):
+        results = [[1,2,3], [4,5,6], [7,8,9]]
+        schema = (("t.a", Property.PropertyType.int),
+            ("t.b", Property.PropertyType.int),
+            ("t.c", Property.PropertyType.int))
+        stream = ProjectStream((), schema, results)
+        self.assertListEqual(list(stream), results)
+
+    def test_all_identified_with_project(self):
+        results = [[1,2,3], [4,5,6], [7,8,9]]
+        schema = (("t.a", Property.PropertyType.int),
+            ("t.b", Property.PropertyType.int),
+            ("t.c", Property.PropertyType.int))
+
+        ## identified
+        # single project
+        expected = [[1],[4],[7]]
+        stream = ProjectStream((("t", "a"),), schema, results)
+        self.assertListEqual(list(stream), expected)
+        self.assertListEqual(stream.schema_names, ["t.a"])
+
+        # multiple project
+        expected = [[1,3],[4,6],[7,9]]
+        stream = ProjectStream((("t", "a"),("t", "c")), schema, results)
+        self.assertListEqual(list(stream), expected)
+        self.assertListEqual(stream.schema_names, ["t.a", "t.c"])
+
+        # out of order
+        expected = [[2,1],[5,4],[8,7]]
+        stream = ProjectStream((("t", "b"),("t", "a")), schema, results)
+        self.assertListEqual(list(stream), expected)
+        self.assertListEqual(stream.schema_names, ["t.b", "t.a"])
+
+        ## unidentified
+        # single project
+        expected = [[1],[4],[7]]
+        stream = ProjectStream(((None, "a"),), schema, results)
+        self.assertListEqual(list(stream), expected)
+        self.assertListEqual(stream.schema_names, ["a"])
+
+        # multiple project
+        expected = [[1,2],[4,5],[7,8]]
+        stream = ProjectStream(((None, "a"),(None, "b")), schema, results)
+        self.assertListEqual(list(stream), expected)
+        self.assertListEqual(stream.schema_names, ["a", "b"])
+
+        # out of order
+        expected = [[2,1],[5,4],[8,7]]
+        stream = ProjectStream(((None, "b"),(None, "a")), schema, results)
+        self.assertListEqual(list(stream), expected)
+        self.assertListEqual(stream.schema_names, ["b", "a"])
+
+    def test_unidentified(self):
+        results = [[1,2,3], [4,5,6], [7,8,9]]
+        expected = [[1,3], [4,6], [7,9]]
+        schema = (("t.a", Property.PropertyType.int),
+            ("b", Property.PropertyType.int),
+            ("t.c", Property.PropertyType.int))
+
+        stream = ProjectStream((), schema, results)
+        self.assertListEqual(list(stream), expected)
+        self.assertListEqual(stream.schema_names, ["t.a", "t.c"])
+
+    def test_ambiguous(self):
+        results = [[1,2,3], [4,5,6], [7,8,9]]
+        schema = (("t.a", Property.PropertyType.int),
+            ("r.b", Property.PropertyType.int),
+            ("t2.a", Property.PropertyType.int))
+
+        # Ambiguousness is determined in index generation
+        with self.assertRaises(AmbiguousPropertyException):
+            stream = ProjectStream(((None, "a"),), schema, results)
+
+    def test_nonexistent(self):
+        results = [[1,2,3], [4,5,6], [7,8,9]]
+        schema = (("t.a", Property.PropertyType.int),
+            ("r.b", Property.PropertyType.int),
+            ("t2.a", Property.PropertyType.int))
+
+        # nonexistent property name
+        with self.assertRaises(NonexistentPropertyException):
+            stream = ProjectStream(((None, "g"),), schema, results)
+
+        # nonexistent identifier
+        with self.assertRaises(NonexistentPropertyException):
+            stream = ProjectStream((("q", "a"),), schema, results)

--- a/tests/traversal/test_query.py
+++ b/tests/traversal/test_query.py
@@ -1,0 +1,78 @@
+import unittest
+
+from graphene.server.server import GrapheneServer
+from graphene.query.planner import QueryPlanner
+from graphene.storage import (StorageManager, GrapheneStore, Property)
+from graphene.expressions import *
+from graphene.errors import *
+from graphene.traversal import Query
+
+class TestQuery(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        GrapheneStore.TESTING = True
+        graphene_store = GrapheneStore()
+        graphene_store.remove_test_datafiles()
+        cls.sm = StorageManager()
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Clean the database so that the tests are independent of one another
+        """
+        graphene_store = GrapheneStore()
+        graphene_store.remove_test_datafiles()
+
+    def test_equality(self):
+        q1 = Query('t', 'a', '=', 1)
+        q2 = Query('t', 'a', '=', 1)
+        self.assertEqual(q1, q2)
+        self.assertFalse(q1 == 5)
+
+    def test_inequality(self):
+        q1 = Query(None, 'a', '=', 1)
+        q2 = Query('t', 'a', '=', 1)
+        self.assertNotEqual(q1, q2)
+
+    def test_test(self):
+        prop_dict = {'t.a': (1, Property.PropertyType.int)}
+
+        q = Query('t', 'a', '=', 1)
+        self.assertTrue(q.test(prop_dict))
+
+        q = Query('t', 'a', '>', 1)
+        self.assertFalse(q.test(prop_dict))
+
+        q = Query('t', 'a', '<', 1)
+        self.assertFalse(q.test(prop_dict))
+
+        q = Query('t', 'a', '>=', 0)
+        self.assertTrue(q.test(prop_dict))
+
+        q = Query('t', 'a', '<=', 0)
+        self.assertFalse(q.test(prop_dict))
+
+        q = Query('t', 'a', '!=', 1)
+        self.assertFalse(q.test(prop_dict))
+
+        q = Query('t', 'a', '!!', 1)
+        self.assertFalse(q.test(prop_dict))
+
+        q = Query('t', 'b', '!=', 1)
+        with self.assertRaises(NonexistentPropertyException):
+            q.test(prop_dict)
+
+    def test_parse_chain(self):
+        schema = (('t.a', Property.PropertyType.int),('t.b', Property.PropertyType.int))
+
+        chain = (('t','a','=','1'),)
+        self.assertListEqual(Query.parse_chain(self.sm, chain, schema), [Query('t','a','=', 1)])
+
+        # This will be changed later when we actually care about booleans
+        chain = (('t','a','=','1'),'AND',('t','b','>','0'))
+        self.assertListEqual(Query.parse_chain(self.sm, chain, schema),
+            [Query('t','a','=', 1), 'AND', Query('t','b','>', 0)])
+
+        chain = (('t','c','>','0'),)
+        with self.assertRaises(NonexistentPropertyException):
+            Query.parse_chain(self.sm, chain, schema)


### PR DESCRIPTION
Implement relation matching.

Can handle queries and returning specific values. Queries still do not do any useful boolean logic. Returning specific values handles possible ambiguity in names and throws error if there is such a problem. Likewise with duplicate property names.
