### PR TITLE
Create_item now calls write_item by default

### DIFF
--- a/graphene/storage/intermediate/general_array_manager.py
+++ b/graphene/storage/intermediate/general_array_manager.py
@@ -63,8 +63,6 @@ class GeneralArrayManager:
                       'items': parts[0]}
         # Create first block using kwargs
         block = self.storeManager.create_item(ids[0], **kwargs)
-        # Write it to the file
-        self.storeManager.write_item(block)
         # First index in linked list
         first_index = ids[0]
 
@@ -88,8 +86,6 @@ class GeneralArrayManager:
                           'items': parts[i]}
             # Create next block
             block = self.storeManager.create_item(ids[i], **kwargs)
-            # Write it to the file
-            self.storeManager.write_item(block)
         # Return the first index of the array in the store
         return first_index
 

--- a/graphene/storage/intermediate/general_name_manager.py
+++ b/graphene/storage/intermediate/general_name_manager.py
@@ -59,8 +59,6 @@ class GeneralNameManager:
 
         # Create first block using kwargs
         block = self.storeManager.create_item(ids[0], **kwargs)
-        # Write it to the file
-        self.storeManager.write_item(block)
         # First index in linked list
         first_index = ids[0]
 
@@ -82,9 +80,6 @@ class GeneralNameManager:
                           'name': name_parts[i]}
             # Create next block
             block = self.storeManager.create_item(ids[i], **kwargs)
-            # Write it to the file
-            self.storeManager.write_item(block)
-
         # Return the first index of the name in the store
         return first_index
 

--- a/graphene/storage/intermediate/general_store_manager.py
+++ b/graphene/storage/intermediate/general_store_manager.py
@@ -31,8 +31,10 @@ class GeneralStoreManager:
         # If no index is given, check for an available ID from the IdStore
         if index == 0:
             index = self.get_indexes()[0]
+        item = self.store.STORAGE_TYPE(index, **kwargs)
+        self.store.write_item(item)
         # Create a type based on the type our store stores
-        return self.store.STORAGE_TYPE(index, **kwargs)
+        return item
 
     def write_item(self, item):
         """

--- a/graphene/storage/intermediate/node_property_store.py
+++ b/graphene/storage/intermediate/node_property_store.py
@@ -9,11 +9,12 @@ class NodePropertyStore:
         Set up the node-property store, which associates
         nodes with their properties.
 
-        :type prop_manager: GeneralStoreManager
+        :param node_manager: Store manager for nodes
         :type node_manager: GeneralStoreManager
+        :param prop_manager: Store manager for properties
+        :type prop_manager: GeneralStoreManager
+        :param prop_string_manager: Store manager for strings
         :type prop_string_manager: GeneralNameManager
-        :param node_manager: store manager for nodes
-        :param prop_manager: store manager for properties
         :return:
         """
         self.node_manager = node_manager
@@ -41,8 +42,7 @@ class NodePropertyStore:
             for prop in properties:
                 self.prop_manager.write_item(prop)
         else:
-            # TODO: Throw an error here
-            pass
+            raise ValueError("Given value is not a Node instance")
 
     def __delitem__(self, key):
         node = self.node_manager.get_item_at_index(key)

--- a/graphene/storage/intermediate/relationship_property_store.py
+++ b/graphene/storage/intermediate/relationship_property_store.py
@@ -36,8 +36,7 @@ class RelationshipPropertyStore:
             for prop in properties:
                 self.prop_manager.write_item(prop)
         else:
-            # TODO: Throw an error here
-            pass
+            raise ValueError("Given value is not a Relationship instance")
 
     def __delitem__(self, key):
         rel = self.relationship_manager.get_item_at_index(key)

--- a/graphene/storage/storage_manager.py
+++ b/graphene/storage/storage_manager.py
@@ -230,12 +230,10 @@ class StorageManager:
                 if i < len(ids) - 1:
                     kwargs["next_type"] = ids[i + 1]
                 prop = type_type_manager.create_item(**kwargs)
-                type_type_manager.write_item(prop)
             new_type = type_manager.create_item(first_type=ids[0],
                                                 name_id=name_index)
         else:
             new_type = type_manager.create_item(name_id=name_index)
-        type_manager.write_item(new_type)
         self.logger.debug("TypeManager wrote new type: %s" % new_type)
         return new_type
 

--- a/graphene/storage/storage_manager.py
+++ b/graphene/storage/storage_manager.py
@@ -129,7 +129,7 @@ class StorageManager:
         del self.relTypeTypeManager
         del self.relTypeTypeNameManager
 
-    # --- Node Storage Methods --- #
+# --- Node Storage Methods --- #
 
     def create_node_type(self, type_name, schema):
         """
@@ -165,7 +165,7 @@ class StorageManager:
         """
         return self.get_type_data(type_name, True)
 
-    # --- Relationship Storage Methods --- #
+# --- Relationship Storage Methods --- #
 
     def create_relationship_type(self, type_name, schema):
         """
@@ -201,7 +201,7 @@ class StorageManager:
         """
         return self.get_type_data(type_name, False)
 
-    # --- Private Storage Methods --- #
+# --- Private Storage Methods --- #
 
     def create_type(self, type_name, schema, node_flag):
         """
@@ -381,40 +381,56 @@ class StorageManager:
             cur_type_type_id = cur_type_type.nextType
         return cur_type, schema
 
-    # --- Node Specific Storage Methods --- #
-    # TODO: generalize the rest of the functions for relationships as well
+# --- Node Specific Storage Methods --- #
     def insert_node(self, node_type, node_properties):
+        """
+        Inserts a node with the given type and properties
+
+        :param node_type: Type of node
+        :type node_type: GeneralType
+        :param node_properties: List of tuples containing (PropertyType, Value)
+        :type node_properties: list
+        :return: Tuple with
+        :rtype:
+        """
         properties = []
         if len(node_properties) > 0:
+            # Get the needed number of IDs to store the properties
             prop_ids = self.property_manager.get_indexes(len(node_properties))
             self.logger.debug("Node properties: %s" % (node_properties,))
+            # Store all the properties
             for i, idx in enumerate(prop_ids):
+                # Get current property type and value for the type
                 prop_type, prop_val = node_properties[i]
                 kwargs = {
                     "index": idx,
                     "prop_type": prop_type
                 }
+                # Non edge cases, prop_ids non-zero
                 if i > 0:
                     kwargs["prev_prop_id"] = prop_ids[i - 1]
-                elif i < len(prop_ids) - 1:
+                if i < len(prop_ids) - 1:
                     kwargs["next_prop_id"] = prop_ids[i + 1]
 
-                # string, so write name
+                # String, so write name
                 if prop_type == Property.PropertyType.string:
                     kwargs["prop_block_id"] = \
                         self.prop_string_manager.write_name(prop_val)
-                # array, so use array manager
+                # Array, so use array manager
                 elif prop_type.value >= Property.PropertyType.intArray.value:
                     kwargs["prop_block_id"] = \
                         self.array_manager.write_array(prop_val, prop_type)
-                # otherwise primitive
+                # Otherwise primitive
                 else:
                     kwargs["prop_block_id"] = prop_val
+                # Create property and add it to the list of properties
                 stored_prop = self.property_manager.create_item(**kwargs)
                 properties.append(stored_prop)
             self.logger.debug("Final properties: %s" % (node_properties,))
+            # Create node with the ID of first property and index of node type
             new_node = self.node_manager.create_item(prop_id=prop_ids[0],
                                                      node_type=node_type.index)
+        # Node with no properties
         else:
             new_node = self.node_manager.create_item(node_type=node_type.index)
         # Update cache with new values and sync with store
@@ -422,10 +438,21 @@ class StorageManager:
         self.nodeprop.sync()
         return (new_node, properties)
 
+    def update_node(self):
+        #TODO
+        pass
+
     def get_node_type(self, node):
         return self.nodeTypeManager.get_item_at_index(node.nodeType)
 
     def get_property_value(self, prop):
+        """
+        Gets the data value for the given property
+
+        :param prop: Property to get value for
+        :type prop: Property
+        :return: Value
+        """
         if prop.type == Property.PropertyType.string:
             return self.prop_string_manager.read_name_at_index(prop.propBlockId)
         elif prop.type.value >= Property.PropertyType.intArray.value:
@@ -454,6 +481,7 @@ class StorageManager:
             if node is not None and node.type == node_type:
                 yield node
 
+# --- Relationship Specific Storage Methods --- #
     def insert_relation(self, rel_type, rel_properties, src_node, dst_node):
         """
         Creates a directed relationship (rel_type) from src_node to dst_node.
@@ -476,7 +504,7 @@ class StorageManager:
                 }
                 if i > 0:
                     prop_kwargs["prev_prop_id"] = prop_ids[i - 1]
-                elif i < len(prop_ids) - 1:
+                if i < len(prop_ids) - 1:
                     prop_kwargs["next_prop_id"] = prop_ids[i + 1]
 
                 if prop_type == Property.PropertyType.string:

--- a/tests/storage/intermediate/test_general_store_manager.py
+++ b/tests/storage/intermediate/test_general_store_manager.py
@@ -55,8 +55,6 @@ class TestGeneralStoreManagerMethods(unittest.TestCase):
 
         # Create an item with type TEST_STORE.STORAGE_TYPE (pass no kwargs)
         item = store_manager.create_item()
-        # Store the item
-        store_manager.write_item(item)
         # Check that the created item is as expected
         self.assertEquals(item, self.TEST_STORE.STORAGE_TYPE(index=item.index))
         # Check that when reading the item from the store it is the same
@@ -71,8 +69,6 @@ class TestGeneralStoreManagerMethods(unittest.TestCase):
 
         # Create an item with type TEST_STORE.STORAGE_TYPE (pass no kwargs)
         item = store_manager.create_item()
-        # Store the item
-        store_manager.write_item(item)
         # Check that the created item is as expected
         self.assertEquals(item, self.TEST_STORE.STORAGE_TYPE(index=item.index))
         # Check that when reading the item from the store it is the same
@@ -94,17 +90,13 @@ class TestGeneralStoreManagerMethods(unittest.TestCase):
         store_manager = GeneralStoreManager(self.TEST_STORE())
 
         # Create and write one blank item
-        item1 = store_manager.create_item()
-        store_manager.write_item(item1)
+        store_manager.create_item()
         # Store the file size with only one item
         one_item_size = store_manager.store.get_file_size()
         # Create and write 3 more items
         item2 = store_manager.create_item()
-        store_manager.write_item(item2)
         item3 = store_manager.create_item()
-        store_manager.write_item(item3)
         item4 = store_manager.create_item()
-        store_manager.write_item(item4)
 
         # Delete the 2nd, then 3rd, then 4th item, this should leave items
         # 2 and 3 untruncated. If the file is properly truncated, it should
@@ -128,10 +120,8 @@ class TestGeneralStoreManagerMethods(unittest.TestCase):
         self.assertEquals(index1, store_manager.store.get_last_file_index())
         self.assertEquals(index2, store_manager.store.get_last_file_index() + 1)
         # Create and write two items with the given index
-        item1 = store_manager.create_item(index1)
-        item2 = store_manager.create_item(index2)
-        store_manager.write_item(item1)
-        store_manager.write_item(item2)
+        store_manager.create_item(index1)
+        store_manager.create_item(index2)
         # Delete the item, the index should now be in the recycled IDs
         store_manager.delete_item_at_index(index1)
 
@@ -146,13 +136,10 @@ class TestGeneralStoreManagerMethods(unittest.TestCase):
         self.assertEquals(store_manager.store.get_last_file_index(), index2)
 
         # Create and write two items with the indexes
-        item1 = store_manager.create_item(index1_new)
-        store_manager.write_item(item1)
-        item2 = store_manager.create_item(index2)
-        store_manager.write_item(item2)
+        store_manager.create_item(index1_new)
+        store_manager.create_item(index2)
         # And a third without an index argument
-        item3 = store_manager.create_item()
-        store_manager.write_item(item3)
+        store_manager.create_item()
         # Delete the second item (second index)
         store_manager.delete_item_at_index(index2)
 


### PR DESCRIPTION
Before create_item did not call write_item. Now it does since there are
no circumstances where the two should not be performed together. Also
causes less errors this way.
