### PR TITLE
Help command

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -54,6 +54,9 @@ exclude_lines =
     # PrettyPrinter does not need testing
     class PrettyPrinter
 
+    # HelpDocs does not need testing
+    class HelpDocs
+
     # GPLogging does not need testing
     class GPLogging
 

--- a/graphene/client/shell.py
+++ b/graphene/client/shell.py
@@ -1,4 +1,5 @@
 from graphene.utils.pretty_printer import PrettyPrinter
+from graphene.utils.help_docs import HelpDocs
 
 import cmd
 import readline
@@ -12,6 +13,8 @@ class Shell(cmd.Cmd):
         cmd.Cmd.__init__(self)
         self.server = server
         self.logger = logging.getLogger(self.__class__.__name__)
+        # Where help documentation is obtained from
+        self.helpDocs = HelpDocs()
 
     def preloop(self):
         self.intro = "Graphene 0.1"
@@ -28,18 +31,22 @@ class Shell(cmd.Cmd):
         :return: Nothing
         :rtype: None
         """
-        # TODO: implement for different types of commands
         # Instance of pretty printer to use for all output
         printer = PrettyPrinter()
         # Make the line whitespace and case insensitive
         line = line.upper().strip()
+        # Get possible help topics
+        help_topics = self.helpDocs.topics
 
-        if line == "MATCH":
-            printer.print_help("MATCH help: ")
-        else:
-            printer.print_help("You can type the following help topics:\n"
-                               "MATCH, INSERT, CREATE")
-            self.logger.debug("Unhandled help request %s" % line)
+        if line in help_topics:
+            self.helpDocs.print_help_topic(line)
+            return
+        # User entered invalid help topic
+        elif len(line) != 0:
+            printer.print_error("ERROR: Unrecognized help topic.")
+        # Print possible help topics
+        printer.print_help("You ask about the following help topics:\n%s"
+                           % "- " + " \n- ".join(help_topics))
 
     def do_EOF(self, line):
         return True

--- a/graphene/utils/help-docs/CREATE.txt
+++ b/graphene/utils/help-docs/CREATE.txt
@@ -1,0 +1,10 @@
+CREATE command
+    Creates schemas for nodes/relations
+    - CREATE TYPE for node types
+    - CREATE RELATION for relation type
+    
+    CREATE (TYPE TypeName|RELATION RELATION_NAME) (prop_name: prop_type, ...)
+ 
+    Relations can have empty schemas, so `CREATE RELATION R ();` is legal
+    Types cannot have empty schemas
+    Available types: string, int, double, bool; also array versions of each

--- a/graphene/utils/help-docs/DELETE.txt
+++ b/graphene/utils/help-docs/DELETE.txt
@@ -1,0 +1,17 @@
+DELETE command
+    Deletes a node/relation from the database (and any references
+    that may refer to it).
+
+    DELETE NODE:
+        Delete a node with a query.
+        
+        DELETE NODE TypeName(query)
+
+    DELETE RELATION:
+        Delete relation with a query, but can also require a node on left 
+        or right with its own query.
+
+        DELETE RELATION RELATION_NAME(query)
+        DELETE RELATION TypeName(query)-RELATION_NAME(query)
+        DELETE RELATION RELATION_NAME(query)->TypeName(query)
+        DELETE RELATION TypeName(query)-RELATION_NAME(query)->TypeName(query)

--- a/graphene/utils/help-docs/DESC.txt
+++ b/graphene/utils/help-docs/DESC.txt
@@ -1,0 +1,3 @@
+DESC command
+    Describes schema of type/relation
+    DESC (TYPE TypeName|RELATION RELATION_NAME)

--- a/graphene/utils/help-docs/DROP.txt
+++ b/graphene/utils/help-docs/DROP.txt
@@ -1,0 +1,3 @@
+DROP command
+    Removes schemas and any nodes/relations/properties referring to them
+    DROP (TYPE TypeName|RELATION RELATION_NAME)

--- a/graphene/utils/help-docs/EXIT-QUIT.txt
+++ b/graphene/utils/help-docs/EXIT-QUIT.txt
@@ -1,0 +1,2 @@
+EXIT/QUIT command
+    Exits server

--- a/graphene/utils/help-docs/INSERT.txt
+++ b/graphene/utils/help-docs/INSERT.txt
@@ -1,0 +1,14 @@
+INSERT command
+    Inserts a node/relation into the database
+    INSERT NODE
+        Can insert multiple nodes of any type.
+        
+        INSERT NODE TypeName(prop1, prop2), OtherTypeName(prop1, prop2, prop3), ...
+    
+    INSERT RELATION
+        Adding properties to relation is like with nodes, but use queries to 
+        determine which nodes to attach to. 
+        Queries work exactly like MATCH queries, except you can't use type 
+        name aliases
+
+        INSERT RELATION TypeName(query)-[RELATION_NAME(prop1, prop2)]->TypeName(query)

--- a/graphene/utils/help-docs/MATCH.txt
+++ b/graphene/utils/help-docs/MATCH.txt
@@ -1,0 +1,14 @@
+MATCH command
+    Used to query nodes or relations
+    - One node: MATCH (node_name:NodeType)
+    - Relation: MATCH(node_name:NodeType)-[rel_name:REL_TYPE]->(node_name:NodeType)
+    Can continue chaining relations with arrows.
+ 
+    Queries: MATCH node_chain WHERE property_name = property_value
+        NOTE: property_name can have an identifier corresponding to node_name.
+        e.g. `MATCH (t:T) WHERE t.a = 3;` or `MATCH (t:T) WHERE a = 3;`. Both work
+
+    Returns: MATCH node_chain RETURN property_name1, property_name2, ...
+        Projects schema.
+        Both queries and projections will notice if there are duplicate 
+        identifiers or ambiguous identifiers

--- a/graphene/utils/help-docs/SHOW.txt
+++ b/graphene/utils/help-docs/SHOW.txt
@@ -1,0 +1,3 @@
+SHOW command
+    Lists types/relations by name
+    SHOW (TYPES|RELATIONS)

--- a/graphene/utils/help-docs/UPDATE.txt
+++ b/graphene/utils/help-docs/UPDATE.txt
@@ -1,0 +1,5 @@
+UPDATE command
+    Updates a node/relation
+    Exactly the same syntax as DELETE except for how to set values
+    
+    UPDATE (NODE ...|RELATION ...) SET prop_name = prop_value, ...

--- a/graphene/utils/help_docs.py
+++ b/graphene/utils/help_docs.py
@@ -1,0 +1,91 @@
+from graphene.utils.pretty_printer import PrettyPrinter
+
+import os
+import logging
+
+class HelpDocs:
+    # Directory containing documentation for commands
+    DOCS_FOLDER = "graphene/utils/help-docs/"
+    # Aliases in the help documentation will be separated by this character
+    # For example: Exit-Quit.txt
+    ALIAS_DELIMETER = "-"
+
+    def __init__(self):
+        # Get a logger to print logging output to
+        self.logger = logging.getLogger(self.__class__.__name__)
+        # Get names of help files
+        help_files = self.get_help_filenames()
+        self.helpFiles = sorted(help_files)
+        # Get topics from the filenames of the help files
+        self.topics = self.topics_from_filenames(help_files)
+
+    def print_help_topic(self, topic):
+        """
+        Prints the documentation for the given help topic
+
+        :param topic: Help topic to print documentation for
+        :type topic: str
+        :return: Nothing
+        :rtype: None
+        """
+        filename = self.get_filename_from_topic(topic)
+        # Return if no file for topic
+        if not filename:
+            return
+        # Try opening the file
+        try:
+            help_file = open(self.DOCS_FOLDER + filename, "r")
+        except IOError:
+            self.logger.warn("Help file deleted while program running "
+                             "for topic: %s" % topic)
+            return
+        # Print the contents of the file using PrettyPrinter
+        printer = PrettyPrinter()
+        printer.print_help(help_file.read())
+
+    def get_help_filenames(self):
+        """
+        Returns a list with the filenames of the help files
+
+        :return: List with names of help files
+        :rtype: list[str]
+        """
+        try:
+            return os.listdir(self.DOCS_FOLDER)
+        except OSError:
+            self.logger.warn("Invalid help docs. folder: %s", self.DOCS_FOLDER)
+            return None
+
+    def topics_from_filenames(self, files):
+        """
+        Get the formatted topics list from the given file names
+
+        :param files: File names of help topics
+        :type files: list[str]
+        :return: Formatted list of topics
+        :rtype: list[str]
+        """
+        topics = []
+        for filename in files:
+            # Strip file extension
+            topic = os.path.splitext(filename)[0]
+            # Split the name on the alias delimeter
+            aliases = topic.split(self.ALIAS_DELIMETER)
+            # Add topic (and possible aliases) to the topics list
+            topics.extend(aliases)
+        return topics
+
+    def get_filename_from_topic(self, topic):
+        """
+        Returns the filename for the file with the given help topic
+
+        :param topic: Topic to get help filename for
+        :type topic: str
+        :return: Filename of help file
+        :rtype: str
+        """
+        for filename in self.helpFiles:
+            # Topic in filename
+            if topic in filename:
+                return filename
+        return None

--- a/graphene/utils/pretty_printer.py
+++ b/graphene/utils/pretty_printer.py
@@ -115,7 +115,7 @@ class PrettyPrinter:
         Pretty prints the given help string with the helpColor field
 
         :param help_str: Help string to print
-        :type help_str: str
+        :type help_str: str | FileIO[str]
         :return: Nothing
         :rtype: None
         """


### PR DESCRIPTION
Help command is now useful, add documentation by editing help-docs folder
Implementation does not have to be changed for new files.
Just stick to the following format:
    - Use the same file for aliases i.e. EXIT-QUIT.txt
    - Name alias files with a "-" separating aliases
    - Stick to 80 lines per file to maintain readability
