### PR TITLE
Implement timer pausing as a context manager.

### DIFF
--- a/graphene/commands/desc_command.py
+++ b/graphene/commands/desc_command.py
@@ -4,7 +4,7 @@ import logging
 
 from graphene.commands.command import Command
 from graphene.errors import TypeDoesNotExistException
-from graphene.utils import PrettyPrinter
+from graphene.utils import PrettyPrinter, CmdTimer
 from graphene.storage import GeneralStore
 
 
@@ -20,7 +20,7 @@ class DescCommand(Command):
 
         self.logger.debug("Describing type with name: %s" % type_name)
 
-    def execute(self, storage_manager, output=sys.stdout, timer=None):
+    def execute(self, storage_manager, output=sys.stdout, timer=CmdTimer()):
         # Instance of pretty printer to use for all output
         printer = PrettyPrinter()
 
@@ -30,12 +30,10 @@ class DescCommand(Command):
             else:
                 type_data, type_schema = storage_manager.get_relationship_data(self.type_name)
             values = [(tt_name, tt_type.name) for tt, tt_name, tt_type in type_schema]
-            if timer is not None:
-                timer.pause() # pause timer for printing
-            printer.print_table(values, header=("Name", "Type"), output=output)
+            with timer.paused():
+                printer.print_table(values, header=("Name", "Type"), output=output)
         except TypeDoesNotExistException as e:
             # If type doesn't exist, just print out error since this is a debug
             # command
-            if timer is not None:
-                timer.pause() # pause timer for printing
-            printer.print_error(e, output)
+            with timer.paused():
+                printer.print_error(e, output)

--- a/graphene/commands/show_command.py
+++ b/graphene/commands/show_command.py
@@ -1,9 +1,10 @@
 from enum import Enum
+import sys
+
 from graphene.commands.command import Command
-from graphene.utils import PrettyPrinter
+from graphene.utils import PrettyPrinter, CmdTimer
 from graphene.storage import GeneralStore
 from graphene.storage import StorageManager
-import sys
 
 class ShowCommand(Command):
     class ShowType(Enum):
@@ -13,7 +14,7 @@ class ShowCommand(Command):
     def __init__(self, show_type):
         self.show_type = show_type
 
-    def execute(self, storage_manager, output=sys.stdout, timer=None):
+    def execute(self, storage_manager, output=sys.stdout, timer=CmdTimer()):
         """
         Execute the show command.
         :param storage_manager: a storage manager.
@@ -49,11 +50,11 @@ class ShowCommand(Command):
                 name_list.append(type_name)
             i += 1
 
-        if timer is not None:
-            timer.pause() # pause timer for printing
-        # Print the resulting name list.
-        if not name_list:
-            printer.print_info(("No %s found.\n" %
-                                self.show_type.name.lower()), output)
-        else:
-            printer.print_list(name_list, self.show_type.name, output=output)
+        with timer.paused():
+            # Print the resulting name list.
+            if not name_list:
+                printer.print_info(("No %s found.\n" %
+                                    self.show_type.name.lower()), output)
+            else:
+                printer.print_list(name_list, self.show_type.name,
+                    output=output)

--- a/graphene/utils/__init__.py
+++ b/graphene/utils/__init__.py
@@ -1,1 +1,2 @@
 from pretty_printer import PrettyPrinter
+from timer import CmdTimer

--- a/graphene/utils/timer.py
+++ b/graphene/utils/timer.py
@@ -1,31 +1,38 @@
+from contextlib import contextmanager
 import time
 
 class CmdTimer:
     def __init__(self):
         self.running = False
-        self.paused = False
+        self.__paused = False
         self.cur_start = None
         self.time_elapsed = 0
 
     def start(self):
-        if self.paused:
-            self.paused = False
+        if self.__paused:
+            self.__paused = False
         else:
             self.time_elapsed = 0
         self.cur_start = time.time()
         self.running = True
 
-    def pause(self):
+    @contextmanager
+    def paused(self):
+        self.__pause()
+        yield
+        self.start()
+
+    def __pause(self):
         if self.cur_start is None:
             return
         self.time_elapsed += time.time() - self.cur_start
         self.cur_start = None
-        self.paused = True
+        self.__paused = True
         self.running = False
         self.cur_start = None
 
     def stop(self):
-        self.paused = False
+        self.__paused = False
         self.running = False
         # If we weren't paused, then add what was left over
         if self.cur_start is not None:


### PR DESCRIPTION
cc @codyhan94 @Davidpena 

We want to make sure that restarting the timer after pausing is never forgotten, so the `pause` method has been made private, and the only option is now the `paused` method. This is used in a `with` statement like so:
#### Old Usage:

``` python
  timer.pause()
  print "foo"
  timer.start()
```
#### New Usage:

``` python
with timer.paused():
    print "foo"
```

All printer statements should be wrapped in these with statements.
