### PR TITLE
Implement the ORDER BY clause.

### DIFF
--- a/graphene/commands/match_command.py
+++ b/graphene/commands/match_command.py
@@ -12,7 +12,7 @@ class MatchCommand(Command):
     def __init__(self, node_chain, query_chain, optional_clauses):
         self.nc = node_chain
         self.qc = query_chain
-        self.rc, self.limit, self.orderby = self.parse_clauses(optional_clauses)
+        self.rc, self.limit, self.orderby = self.parse_clauses(optional_clauses or [])
 
     def parse_clauses(self, clauses):
         """

--- a/graphene/commands/match_command.py
+++ b/graphene/commands/match_command.py
@@ -1,18 +1,47 @@
 import sys
+from collections import Counter
 
+from graphene.errors import TooManyClausesException
+from graphene.expressions import OptionalClause
 from graphene.traversal import *
 from graphene.commands.command import Command
 from graphene.utils import PrettyPrinter
 from graphene.query.planner import QueryPlanner
 
 class MatchCommand(Command):
-    def __init__(self, node_chain, query_chain, return_chain, limit):
+    def __init__(self, node_chain, query_chain, optional_clauses):
         self.nc = node_chain
         self.qc = query_chain
-        self.rc = return_chain or ()
-        self.limit = limit or 0
-        if self.limit < 0:
-            self.limit = 0
+        self.rc, self.limit, self.orderby = self.parse_clauses(optional_clauses)
+
+    def parse_clauses(self, clauses):
+        """
+        We have to sanitize these optional clauses. Since they can come in any
+        order, the cleanest way to parse the tree is to allow any number of them
+        and ensure that there are no more than 1 of each type.
+        """
+        ctr = Counter(clause_type for clause_type, clause_value in clauses)
+        if ctr[OptionalClause.ORDERBY] > 1:
+            raise TooManyClausesException("There are too many ORDER BY clauses."
+                " Only one ORDER BY clause is permitted.")
+        if ctr[OptionalClause.RETURN] > 1:
+            raise TooManyClausesException("There are too many RETURN clauses."
+                " Only one RETURN clause is permitted.")
+        if ctr[OptionalClause.LIMIT] > 1:
+            raise TooManyClausesException("There are too many LIMIT clauses."
+                " Only one LIMIT clause is permitted.")
+        clauses = dict(clauses)
+
+        rc = clauses[OptionalClause.RETURN] \
+            if OptionalClause.RETURN in clauses else ()
+        limit = clauses[OptionalClause.LIMIT] \
+            if OptionalClause.LIMIT in clauses else 0
+        if limit < 0:
+            # No negative limits
+            limit = 0
+        orderby = clauses[OptionalClause.ORDERBY] \
+            if OptionalClause.ORDERBY in clauses else []
+        return (rc, limit, orderby)
 
     def __repr__(self):
         lst = ["\t%s" % chain for chain in self.nc]

--- a/graphene/commands/match_command.py
+++ b/graphene/commands/match_command.py
@@ -62,7 +62,8 @@ class MatchCommand(Command):
 
         # Create a planner and execute given a node chain and query chain
         planner = QueryPlanner(storage_manager)
-        schema, results = planner.execute(self.nc, self.qc, self.rc, limit=self.limit)
+        schema, results = planner.execute(self.nc, self.qc, self.rc,
+            limit=self.limit, orderby=self.orderby)
 
         if timer is not None:
             timer.pause() # pause timer for printing

--- a/graphene/errors/query_errors.py
+++ b/graphene/errors/query_errors.py
@@ -7,6 +7,9 @@ class NonexistentPropertyException(Exception):
     """Error for creating a type that already exists."""
     pass
 
+class TooManyClausesException(Exception):
+    """Error for too many ORDER BY, RETURN or LIMIT clauses."""
+    pass
 
 class DuplicatePropertyException(Exception):
     """Error for attempting to get type data for a non-existent type."""

--- a/graphene/expressions/optional_clause.py
+++ b/graphene/expressions/optional_clause.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+class OptionalClause(Enum):
+  RETURN = 1
+  LIMIT = 2
+  ORDERBY = 3

--- a/graphene/query/planner.py
+++ b/graphene/query/planner.py
@@ -174,7 +174,7 @@ class QueryPlanner:
 
         return iter_tree
 
-    def get_orderby_fn(self, schema, chain, is_relation=False):
+    def get_orderby_indexes(self, schema, chain):
         schema_names = [name for name, ttype in schema]
         schema_base_names = [name.split(".")[-1] for name, ttype in schema]
         indexes = []
@@ -196,6 +196,10 @@ class QueryPlanner:
                     raise NonexistentPropertyException("Property name `%s` does not exist." % key)
                 else:
                     indexes.append((schema_names.index(key), multiplier))
+        return indexes
+
+    def get_orderby_fn(self, schema, chain, is_relation=False):
+        indexes = self.get_orderby_indexes(schema, chain)
         if is_relation:
             def cmp_fn(a, b):
                 for i, direction in indexes:


### PR DESCRIPTION
cc @codyhan94 @Davidpena 

These commits implement the `ORDER BY` clause, allowing for sorting of results in `MATCH` commands.

This fixes #30.
