### PR TITLE
Fix issue #45.

### DIFF
--- a/graphene/errors/query_errors.py
+++ b/graphene/errors/query_errors.py
@@ -4,7 +4,8 @@ Query custom exceptions.
 
 
 class NonexistentPropertyException(Exception):
-    """Error for creating a type that already exists."""
+    """Error for accessing or attempting to modify a property that does not
+    exist."""
     pass
 
 class TooManyClausesException(Exception):
@@ -12,11 +13,15 @@ class TooManyClausesException(Exception):
     pass
 
 class DuplicatePropertyException(Exception):
-    """Error for attempting to get type data for a non-existent type."""
+    """Error for attempting to query with a schema containing duplicate property
+    names.."""
     pass
 
 class AmbiguousPropertyException(Exception):
-    """Error for attempting to store the incorrect data type for a property."""
+    """Error for attempting to query with a schema containing ambiguous property
+    names. That is, a query is created where a property name could refer to more
+    than one type in the matching portion of the query, but no specific node
+    was designated for that property to refer to."""
     pass
 
 class BadPropertyException(Exception):

--- a/graphene/errors/storage_manager_errors.py
+++ b/graphene/errors/storage_manager_errors.py
@@ -7,7 +7,6 @@ class TypeAlreadyExistsException(Exception):
     """Error for creating a type that already exists."""
     pass
 
-
 class TypeDoesNotExistException(Exception):
     """Error for attempting to get type data for a non-existent type."""
     pass


### PR DESCRIPTION
This updates the docstrings for graphene.errors.query_errors to make them more
useful and actually meaningful.
