### PR TITLE
ALTER command

### DIFF
--- a/graphene/commands/alter_command.py
+++ b/graphene/commands/alter_command.py
@@ -32,4 +32,4 @@ class AlterCommand(Command):
             elif mod.type == AlterCommand.AlterType.CHANGE_PROPERTY:
                 storage_manager.change_property(self.type_name, mod.n, mod.t, self.node_flag)
             elif mod.type == AlterCommand.AlterType.RENAME_PROPERTY:
-                print "\trename property %s.%s to %s.%s." % (self.type_name, mod.n, self.type_name, mod.n2)
+                storage_manager.rename_property(self.type_name, mod.n, mod.n2, self.node_flag)

--- a/graphene/commands/alter_command.py
+++ b/graphene/commands/alter_command.py
@@ -32,5 +32,6 @@ class AlterCommand(Command):
                 storage_manager.add_property(self.type_name, mod.n, mod.t, self.node_flag)
             elif mod.type == AlterCommand.AlterType.CHANGE_PROPERTY:
                 print "\tchange property type of %s.%s to %s." % (self.type_name, mod.n, mod.t)
+                storage_manager.change_property(self.type_name, mod.n, mod.t, self.node_flag)
             elif mod.type == AlterCommand.AlterType.RENAME_PROPERTY:
                 print "\trename property %s.%s to %s.%s." % (self.type_name, mod.n, self.type_name, mod.n2)

--- a/graphene/commands/alter_command.py
+++ b/graphene/commands/alter_command.py
@@ -24,14 +24,12 @@ class AlterCommand(Command):
         :param storage_manager: manager that stores the relation to disk
         :return: None
         """
-        print "Altering %s %s:" % ("node" if self.node_flag else "relation", self.type_name)
         for mod in self.mods:
             if mod.type == AlterCommand.AlterType.DROP_PROPERTY:
                 storage_manager.drop_property(self.type_name, mod.n, self.node_flag)
             elif mod.type == AlterCommand.AlterType.ADD_PROPERTY:
                 storage_manager.add_property(self.type_name, mod.n, mod.t, self.node_flag)
             elif mod.type == AlterCommand.AlterType.CHANGE_PROPERTY:
-                print "\tchange property type of %s.%s to %s." % (self.type_name, mod.n, mod.t)
                 storage_manager.change_property(self.type_name, mod.n, mod.t, self.node_flag)
             elif mod.type == AlterCommand.AlterType.RENAME_PROPERTY:
                 print "\trename property %s.%s to %s.%s." % (self.type_name, mod.n, self.type_name, mod.n2)

--- a/graphene/commands/alter_command.py
+++ b/graphene/commands/alter_command.py
@@ -29,7 +29,7 @@ class AlterCommand(Command):
             if mod.type == AlterCommand.AlterType.DROP_PROPERTY:
                 storage_manager.drop_property(self.type_name, mod.n, self.node_flag)
             elif mod.type == AlterCommand.AlterType.ADD_PROPERTY:
-                print "\tadd property %s.%s with type %s." % (self.type_name, mod.n, mod.t)
+                storage_manager.add_property(self.type_name, mod.n, mod.t, self.node_flag)
             elif mod.type == AlterCommand.AlterType.CHANGE_PROPERTY:
                 print "\tchange property type of %s.%s to %s." % (self.type_name, mod.n, mod.t)
             elif mod.type == AlterCommand.AlterType.RENAME_PROPERTY:

--- a/graphene/commands/alter_command.py
+++ b/graphene/commands/alter_command.py
@@ -27,7 +27,7 @@ class AlterCommand(Command):
         print "Altering %s %s:" % ("node" if self.node_flag else "relation", self.type_name)
         for mod in self.mods:
             if mod.type == AlterCommand.AlterType.DROP_PROPERTY:
-                print "\tdrop property %s.%s." % (self.type_name, mod.n)
+                storage_manager.drop_property(self.type_name, mod.n, self.node_flag)
             elif mod.type == AlterCommand.AlterType.ADD_PROPERTY:
                 print "\tadd property %s.%s with type %s." % (self.type_name, mod.n, mod.t)
             elif mod.type == AlterCommand.AlterType.CHANGE_PROPERTY:

--- a/graphene/commands/alter_command.py
+++ b/graphene/commands/alter_command.py
@@ -1,0 +1,36 @@
+import sys
+from enum import Enum
+
+from graphene.storage import StorageManager
+from graphene.commands.command import Command
+
+
+class AlterCommand(Command):
+    class AlterType(Enum):
+        DROP_PROPERTY = 1
+        ADD_PROPERTY = 2
+        CHANGE_PROPERTY = 3
+        RENAME_PROPERTY = 4
+
+    def __init__(self, type_name, mods, node_flag):
+        self.type_name = type_name
+        self.mods = mods
+        self.node_flag = node_flag
+
+    def execute(self, storage_manager, output=sys.stdout, timer=None):
+        """
+        Create the relation specified by this class.
+        :type storage_manager: StorageManager
+        :param storage_manager: manager that stores the relation to disk
+        :return: None
+        """
+        print "Altering %s %s:" % ("node" if self.node_flag else "relation", self.type_name)
+        for mod in self.mods:
+            if mod.type == AlterCommand.AlterType.DROP_PROPERTY:
+                print "\tdrop property %s.%s." % (self.type_name, mod.n)
+            elif mod.type == AlterCommand.AlterType.ADD_PROPERTY:
+                print "\tadd property %s.%s with type %s." % (self.type_name, mod.n, mod.t)
+            elif mod.type == AlterCommand.AlterType.CHANGE_PROPERTY:
+                print "\tchange property type of %s.%s to %s." % (self.type_name, mod.n, mod.t)
+            elif mod.type == AlterCommand.AlterType.RENAME_PROPERTY:
+                print "\trename property %s.%s to %s.%s." % (self.type_name, mod.n, self.type_name, mod.n2)

--- a/graphene/storage/base/property.py
+++ b/graphene/storage/base/property.py
@@ -51,6 +51,35 @@ class Property:
         doubleArray = 15
         stringArray = 16
 
+        @staticmethod
+        def get_base_type(prop_type):
+            assert Property.PropertyType.is_array(prop_type)
+            return Property.PropertyType(prop_type.value - 8)
+
+        @staticmethod
+        def get_array_type(prop_type):
+            assert Property.PropertyType.is_primitive(prop_type) or \
+                   Property.PropertyType.is_string(prop_type)
+            return Property.PropertyType(prop_type.value + 8)
+
+        @staticmethod
+        def is_array(prop_type):
+            return prop_type.value >= 9
+
+        @staticmethod
+        def is_primitive(prop_type):
+            return 1 <= prop_type.value <= 7
+
+        @staticmethod
+        def is_numerical(prop_type):
+            return Property.PropertyType.is_primitive(prop_type) and \
+                   prop_type not in [Property.PropertyType.bool,
+                                           Property.PropertyType.char]
+
+        @staticmethod
+        def is_string(prop_type):
+            return prop_type.value == 8
+
     def __init__(self, index=0, in_use=True, prop_type=PropertyType.undefined,
                  name_id=0, prev_prop_id=0, next_prop_id=0, prop_block_id=0):
         """
@@ -144,7 +173,7 @@ class Property:
         :return: True if primitive, False otherwise
         :rtype: bool
         """
-        return self.type.value >= 1 and self.type.value <= 7
+        return Property.PropertyType.is_primitive(self.type)
 
     def is_string(self):
         """
@@ -153,7 +182,7 @@ class Property:
         :return: True if string, False otherwise
         :rtype: bool
         """
-        return self.type.value == 8
+        return Property.PropertyType.is_string(self.type)
 
     def is_array(self):
         """
@@ -162,4 +191,4 @@ class Property:
         :return: True if string, False otherwise
         :rtype: bool
         """
-        return self.type.value >= 9
+        return Property.PropertyType.is_array(self.type)

--- a/graphene/storage/base/property.py
+++ b/graphene/storage/base/property.py
@@ -2,6 +2,28 @@ from enum import Enum
 
 
 class Property:
+    class DefaultValue:
+        # Primitive types
+        int = 0
+        long = 0
+        bool = False
+        short = 0
+        char = ''
+        float = 0.0
+        double = 0.0
+        # String type (dynamic)
+        string = ""
+        # Array types (dynamic)
+        intArray = []
+        longArray = []
+        boolArray = []
+        shortArray = []
+        charArray = []
+        floatArray = []
+        doubleArray = []
+        stringArray = []
+
+
     class PropertyType(Enum):
         """
         Types of properties. NOTE: change is_primitive, is_string, and is_array

--- a/graphene/storage/storage_manager.py
+++ b/graphene/storage/storage_manager.py
@@ -1053,8 +1053,6 @@ class StorageManager:
             old_value = item_prop.properties[prop_index]
             new_value = self.convert_value_between_types(old_value, old_type, new_type)
 
-            print "%s -> %s" % (old_value, new_value)
-
             cur_prop_id = item.propId
             i = 0
             while cur_prop_id != 0:
@@ -1073,6 +1071,12 @@ class StorageManager:
                             # Didn't have an array before, so have to write an
                             # array and put it there
                             cur_prop.propBlockId = self.array_manager.write_array(new_value, new_type)
+                    elif Property.PropertyType.is_string(new_type):
+                        if Property.PropertyType.is_string(old_type):
+                            # Already had a string, so update
+                            self.prop_string_manager.update_string_at_index(cur_prop.propBlockId, new_value)
+                        else:
+                            cur_prop.propBlockId = self.prop_string_manager.write_string(new_value)
                     else:
                         cur_prop.propBlockId = new_value
                 props.append(cur_prop)

--- a/graphene/storage/storage_manager.py
+++ b/graphene/storage/storage_manager.py
@@ -908,12 +908,11 @@ class StorageManager:
 
             # Now we remove the property from every node of this type.
             cur_prop_id = item.propId
-            props = []
+            prop_ids = []
             cur_prop_idx = 0
             while cur_prop_id != 0:
                 prop = self.property_manager.get_item_at_index(cur_prop_id)
 
-                prev_prop_id = cur_prop_id
                 cur_prop_id = prop.nextPropId
 
                 # The properties are linked in the same order as the schema, so
@@ -929,19 +928,30 @@ class StorageManager:
                     else:
                         # The first property
                         item.propId = prop.nextPropId
+
+                    if prop.nextPropId != 0:
+                        # Not the last property
+                        next_prop = self.property_manager.get_item_at_index(prop.nextPropId)
+                        next_prop.prevPropId = prop.prevPropId
+                        self.property_manager.write_item(next_prop)
                     # Actually delete it
                     self.delete_property(prop)
                 else:
                     # Otherwise, add it to the property list we'll need to
-                    # update the cache with
-                    props.append(prop)
+                    # update the cache with. We use ids here rather than the
+                    # actual properties because we need to ensure we have the
+                    # updated value.
+                    prop_ids.append(prop.index)
 
                 cur_prop_idx += 1
 
             # Update the cache to reflect the new properties
+            props = map(self.property_manager.get_item_at_index, prop_ids)
             cache[item.index] = (item, props)
         # Sync cache to disk
         cache.sync()
+
+
 
 
 # --- Tools --- #

--- a/tests/storage/base/test_property.py
+++ b/tests/storage/base/test_property.py
@@ -79,3 +79,33 @@ class TestPropertyMethods(unittest.TestCase):
         self.assertTrue(prop3.is_array())
         self.assertFalse(prop3.is_string())
         self.assertFalse(prop3.is_primitive())
+
+    def test_property_type_methods(self):
+        self.assertFalse(Property.PropertyType.is_array(Property.PropertyType.int))
+        self.assertFalse(Property.PropertyType.is_string(Property.PropertyType.int))
+        self.assertTrue(Property.PropertyType.is_primitive(Property.PropertyType.int))
+        self.assertTrue(Property.PropertyType.is_numerical(Property.PropertyType.int))
+
+        self.assertFalse(Property.PropertyType.is_numerical(Property.PropertyType.bool))
+        self.assertFalse(Property.PropertyType.is_numerical(Property.PropertyType.char))
+
+        self.assertTrue(Property.PropertyType.is_array(Property.PropertyType.intArray))
+        self.assertFalse(Property.PropertyType.is_string(Property.PropertyType.intArray))
+        self.assertFalse(Property.PropertyType.is_primitive(Property.PropertyType.intArray))
+        self.assertFalse(Property.PropertyType.is_numerical(Property.PropertyType.intArray))
+
+        self.assertFalse(Property.PropertyType.is_array(Property.PropertyType.string))
+        self.assertTrue(Property.PropertyType.is_string(Property.PropertyType.string))
+        self.assertFalse(Property.PropertyType.is_primitive(Property.PropertyType.string))
+        self.assertFalse(Property.PropertyType.is_numerical(Property.PropertyType.string))
+
+        self.assertFalse(Property.PropertyType.is_array(Property.PropertyType.undefined))
+        self.assertFalse(Property.PropertyType.is_string(Property.PropertyType.undefined))
+        self.assertFalse(Property.PropertyType.is_primitive(Property.PropertyType.undefined))
+        self.assertFalse(Property.PropertyType.is_numerical(Property.PropertyType.undefined))
+
+        with self.assertRaises(AssertionError):
+            Property.PropertyType.get_base_type(Property.PropertyType.int)
+            Property.PropertyType.get_array_type(Property.PropertyType.intArray)
+        self.assertEqual(Property.PropertyType.get_base_type(Property.PropertyType.intArray), Property.PropertyType.int)
+        self.assertEqual(Property.PropertyType.get_array_type(Property.PropertyType.int), Property.PropertyType.intArray)

--- a/tests/storage/intermediate/test_storage_manager.py
+++ b/tests/storage/intermediate/test_storage_manager.py
@@ -1061,8 +1061,20 @@ class TestStorageManagerMethods(unittest.TestCase):
         self.assertEqual(type(new_value), float)
         self.assertEqual(new_value, 0.0)
 
+        self.sm.change_property(name, "a", "string", node_flag)
+
+        new_value = get_item(i.index).properties[1]
+        self.assertEqual(type(new_value), unicode)
+        self.assertEqual(new_value, "")
+
+        self.sm.change_property(name, "c", "string", node_flag)
+
+        new_value = get_item(i.index).properties[0]
+        self.assertEqual(type(new_value), unicode)
+        self.assertEqual(new_value, "a")
+
     def test_change_property(self):
-        schema = ( ("c", "string[]"), ("a", "int"), )
+        schema = ( ("c", "string"), ("a", "int"), )
         types = (Property.PropertyType.string, Property.PropertyType.int,)
         data = zip(types, ("a", 1,))
         data2 = zip(types, ("b", 2,))

--- a/tests/storage/intermediate/test_storage_manager.py
+++ b/tests/storage/intermediate/test_storage_manager.py
@@ -957,3 +957,68 @@ class TestStorageManagerMethods(unittest.TestCase):
         p3 = self.sm.relprop[r3.index][1]
 
         self.drop_property_three_items_five_props("R", (r1, p1), (r2, p2), (r3, p3), False)
+
+    def add_property_three_items(self, name, (i1, p1), (i2, p2), (i3, p3), node_flag):
+        if node_flag:
+            item_manager = self.sm.node_manager
+            get_item = self.sm.get_node
+        else:
+            item_manager = self.sm.relationship_manager
+            get_item = self.sm.get_relation
+
+        i1i, p1i = i1.index, map(lambda p: p.index, p1)
+        i2i, p2i = i2.index, map(lambda p: p.index, p2)
+        i3i, p3i = i3.index, map(lambda p: p.index, p3)
+
+        i1props = map(lambda i: self.sm.get_property_value(
+                                self.sm.property_manager.get_item_at_index(i)),
+                      p1i)
+        i2props = map(lambda i: self.sm.get_property_value(
+                                self.sm.property_manager.get_item_at_index(i)),
+                      p2i)
+        i3props = map(lambda i: self.sm.get_property_value(
+                                self.sm.property_manager.get_item_at_index(i)),
+                      p3i)
+
+        props_to_add = (
+            ("b", "int", Property.PropertyType.int, Property.DefaultValue.int),
+            ("c", "float", Property.PropertyType.float, Property.DefaultValue.float),
+            ("d", "string", Property.PropertyType.string, Property.DefaultValue.string),
+            ("e", "bool", Property.PropertyType.bool, Property.DefaultValue.bool),
+            ("f", "int[]", Property.PropertyType.intArray, Property.DefaultValue.intArray),
+        )
+
+        for prop_name, prop_type, prop_tt_type, default_val in props_to_add:
+            i1props.append(default_val)
+            i2props.append(default_val)
+            i3props.append(default_val)
+
+            new_tt = self.sm.add_property(name, prop_name, prop_type, node_flag)
+
+            self.assertEqual(new_tt.propertyType, prop_tt_type)
+
+            self.assertListEqual(get_item(i1i).properties, i1props)
+            self.assertListEqual(get_item(i2i).properties, i2props)
+            self.assertListEqual(get_item(i3i).properties, i3props)
+
+    def test_add_property(self):
+        schema = ( ("a", "string"), )
+        types = (Property.PropertyType.string,)
+        data1 = zip(types, ("a",))
+        data2 = zip(types, ("b",))
+        data3 = zip(types, ("c",))
+
+        t = self.sm.create_node_type("T", schema)
+        n1, p1 = self.sm.insert_node(t, data1)
+        n2, p2 = self.sm.insert_node(t, data2)
+        n3, p3 = self.sm.insert_node(t, data3)
+        self.add_property_three_items("T", (n1, p1), (n2, p2), (n3, p3), True)
+
+        r = self.sm.create_relationship_type("R", ())
+        r1 = self.sm.insert_relation(r, (), n1, n2)
+        p1 = self.sm.relprop[r1.index][1]
+        r2 = self.sm.insert_relation(r, (), n1, n3)
+        p2 = self.sm.relprop[r2.index][1]
+        r3 = self.sm.insert_relation(r, (), n2, n3)
+        p3 = self.sm.relprop[r3.index][1]
+        self.add_property_three_items("R", (r1, p1), (r2, p2), (r3, p3), False)

--- a/tests/storage/intermediate/test_storage_manager.py
+++ b/tests/storage/intermediate/test_storage_manager.py
@@ -1091,6 +1091,28 @@ class TestStorageManagerMethods(unittest.TestCase):
 
         self.change_property_item("R", (r, rp), False)
 
+    def rename_property_helper(self, name, node_flag):
+        _, type_schema = self.sm.get_type_data(name, node_flag)
+        self.assertEqual(type_schema[0][1], "a")
+
+        self.sm.rename_property(name, "a", "b", node_flag)
+
+        _, type_schema = self.sm.get_type_data(name, node_flag)
+        self.assertEqual(type_schema[0][1], "b")
+
+        with self.assertRaises(NonexistentPropertyException):
+            self.sm.rename_property(name, "a", "b", node_flag)
+
+    def test_rename_property(self):
+        schema = ( ("a", "string"), )
+        types = (Property.PropertyType.string,)
+
+        t = self.sm.create_node_type("T", schema)
+        self.rename_property_helper("T", True)
+
+        r = self.sm.create_relationship_type("R", schema)
+        self.rename_property_helper("R", False)
+
     # --- Helpers --- #
     def test_is_convertible(self):
         numerical_types = [


### PR DESCRIPTION
This PR implements the `ALTER` command. We can use `ALTER` to rename schema properties, change their types, add or remove them. For example:

```
// Add a property named foo with type int[]
ALTER TYPE Person ADD PROPERTY foo int[];
// Removes the property named foo, if it exists
ALTER TYPE Person DROP PROPERTY foo;
// Changes the type of the property named foo to the new type, converting all values if applicable
ALTER TYPE Person CHANGE PROPERTY foo float[];
// Renames the property named foo to be named bar
ALTER TYPE Person RENAME PROPERTY foo bar;
```

`CHANGE PROPERTY` will convert types in a reasonable manner; if there is a way to convert values that makes sense, it does that conversion; otherwise, Graphene will simply choose the default value for the new type.

cc @Davidpena 
